### PR TITLE
Refactor/card metadata

### DIFF
--- a/opsml/app/routes/data.py
+++ b/opsml/app/routes/data.py
@@ -45,7 +45,7 @@ def download_data_profile(
         storage_client = request.app.state.storage_client
         return StreamingResponse(
             storage_client.iterfile(
-                file_path=datacard.uris.profile_html_uri,
+                file_path=datacard.metadata.uris.profile_html_uri,
                 chunk_size=CHUNK_SIZE,
             ),
             media_type="application/octet-stream",

--- a/opsml/app/routes/models.py
+++ b/opsml/app/routes/models.py
@@ -136,6 +136,7 @@ def post_model_metrics(
         )
 
     card = cards[0]
+
     if card.get("runcard_uid") is None:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/opsml/model/challenger.py
+++ b/opsml/model/challenger.py
@@ -288,8 +288,10 @@ class ModelChallenger:
         ):
             # get challenger metric
             if value is None:
-                if self._challenger.runcard_uid is not None:
-                    self.challenger_metric = self._get_runcard_metric(self._challenger.runcard_uid, metric_name=name)
+                if self._challenger.metadata.runcard_uid is not None:
+                    self.challenger_metric = self._get_runcard_metric(
+                        self._challenger.metadata.runcard_uid, metric_name=name
+                    )
                 else:
                     raise ValueError("Challenger and champions must be associated with a registered RunCard")
             else:

--- a/opsml/model/types.py
+++ b/opsml/model/types.py
@@ -129,6 +129,48 @@ class ModelReturn(BaseModel):
     model_config = ConfigDict(frozen=False, protected_namespaces=("protect_",))
 
 
+class ExtraOnnxArgs(BaseModel):
+    """
+    input_names (List[str]): Optional list containing input names for model inputs.
+    This is a PyTorch-specific attribute
+    output_names (List[str]): Optional list containing output names for model outputs.
+    This is a PyTorch-specific attribute
+    dynamic_axes (Dictionary): Optional PyTorch attribute that defines dynamic axes
+    constant_folding (bool): Whether to use constant folding optimization. Default is True
+    """
+
+    input_names: List[str]
+    output_names: List[str]
+    dynamic_axes: Optional[Dict[str, Dict[int, str]]] = None
+    do_constant_folding: bool = True
+    export_params: bool = True
+    verbose: bool = False
+    options: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class ModelCardUris:
+    modelcard_uri: Optional[str] = None
+    trained_model_uri: Optional[str] = None
+    onnx_model_uri: Optional[str] = None
+    model_metadata_uri: Optional[str] = None
+    sample_data_uri: Optional[str] = None
+
+    model_config = ConfigDict(protected_namespaces=("protect_",))
+
+
+class ModelCardMetadata(BaseModel):
+    onnx_model_data: Optional[DataDict] = None
+    onnx_model_def: Optional[OnnxModelDefinition] = None
+    sample_data_type: Optional[str] = None
+    model_type: Optional[str] = None
+    additional_onnx_args: Optional[ExtraOnnxArgs] = None
+    data_schema: Optional[ApiDataSchemas] = None
+    runcard_uid: Optional[str] = None
+    pipelinecard_uid: Optional[str] = None
+    uris: ModelCardUris = ModelCardUris()
+
+
 class Base(BaseModel):
     model_config = ConfigDict(frozen=False)
 
@@ -249,25 +291,6 @@ class PydanticDataTypes(Enum):
     INTEGER = int
     STRING = str
     ANY = Any
-
-
-class ExtraOnnxArgs(BaseModel):
-    """
-    input_names (List[str]): Optional list containing input names for model inputs.
-    This is a PyTorch-specific attribute
-    output_names (List[str]): Optional list containing output names for model outputs.
-    This is a PyTorch-specific attribute
-    dynamic_axes (Dictionary): Optional PyTorch attribute that defines dynamic axes
-    constant_folding (bool): Whether to use constant folding optimization. Default is True
-    """
-
-    input_names: List[str]
-    output_names: List[str]
-    dynamic_axes: Optional[Dict[str, Dict[int, str]]] = None
-    do_constant_folding: bool = True
-    export_params: bool = True
-    verbose: bool = False
-    options: Optional[Dict[str, Any]] = None
 
 
 @dataclass

--- a/opsml/model/types.py
+++ b/opsml/model/types.py
@@ -150,6 +150,19 @@ class ExtraOnnxArgs(BaseModel):
 
 @dataclass
 class ModelCardUris:
+    """Uri holder for ModelCardMetadata
+
+    Args:
+        modelcard_uri:
+            URI of modelcard
+        trained_model_uri:
+            URI where model is stored
+        sample_data_uri:
+            URI of trained model sample data
+        model_metadata_uri:
+            URI where model metadata is stored
+    """
+
     modelcard_uri: Optional[str] = None
     trained_model_uri: Optional[str] = None
     onnx_model_uri: Optional[str] = None
@@ -160,6 +173,30 @@ class ModelCardUris:
 
 
 class ModelCardMetadata(BaseModel):
+    """Create modelcard metadata
+
+    Args:
+        description:
+            Description for your model
+        onnx_model_data:
+            Pydantic model containing onnx data schema
+        onnx_model_def:
+            Pydantic model containing OnnxModel definition
+        model_type:
+            Type of model
+        data_schema:
+            Optional dictionary of the data schema used in model training
+        additional_onnx_args:
+            Optional pydantic model containing Torch args for model conversion to onnx.
+        runcard_uid:
+            RunCard associated with the ModelCard
+        pipelinecard_uid:
+            Associated PipelineCard
+        uris:
+            ModelCardUris object containing all uris associated with ModelCard
+    """
+
+    description: Optional[str] = None
     onnx_model_data: Optional[DataDict] = None
     onnx_model_def: Optional[OnnxModelDefinition] = None
     sample_data_type: Optional[str] = None

--- a/opsml/projects/base/_active_run.py
+++ b/opsml/projects/base/_active_run.py
@@ -138,7 +138,7 @@ class ActiveRun:
 
         # add runuid to card
         if isinstance(card, (DataCard, ModelCard)):
-            card.runcard_uid = self.runcard.uid
+            card.metadata.runcard_uid = self.runcard.uid
 
         CardHandler.register_card(
             registries=self._info.registries,

--- a/opsml/registry/__init__.py
+++ b/opsml/registry/__init__.py
@@ -1,5 +1,7 @@
 from opsml.registry.cards import DataCard, ModelCard, PipelineCard, RunCard
 from opsml.registry.cards.types import CardInfo
 from opsml.registry.data.splitter import DataSplit
+from opsml.registry.data.types import DataCardMetadata
+from opsml.model.types import ModelCardMetadata
 from opsml.registry.sql.registry import CardRegistries, CardRegistry
 from opsml.registry.sql.semver import VersionType

--- a/opsml/registry/cards/__init__.py
+++ b/opsml/registry/cards/__init__.py
@@ -6,3 +6,4 @@ from opsml.registry.cards.data import DataCard
 from opsml.registry.cards.model import ModelCard
 from opsml.registry.cards.types import CardInfo
 from opsml.registry.data.splitter import DataSplit
+from opsml.registry.data.types import DataCardMetadata

--- a/opsml/registry/cards/__init__.py
+++ b/opsml/registry/cards/__init__.py
@@ -3,7 +3,7 @@ from opsml.registry.cards.pipeline import PipelineCard
 from opsml.registry.cards.project import ProjectCard
 from opsml.registry.cards.run import RunCard
 from opsml.registry.cards.data import DataCard
-from opsml.registry.cards.model import ModelCard
+from opsml.registry.cards.model import ModelCard, ModelCardMetadata
 from opsml.registry.cards.types import CardInfo
 from opsml.registry.data.splitter import DataSplit
 from opsml.registry.data.types import DataCardMetadata

--- a/opsml/registry/cards/card_saver.py
+++ b/opsml/registry/cards/card_saver.py
@@ -124,13 +124,13 @@ class DataCardArtifactSaver(CardArtifactSaver):
 
         self._set_storage_spec(
             filename=SaveName.DATACARD.value,
-            uri=self.card.uris.datacard_uri,
+            uri=self.card.metadata.uris.datacard_uri,
         )
 
         exclude_attr = {"data_profile", "storage_client"}
 
         # ImageDataSets use pydantic models for data
-        if self.card.data_type != AllowedTableTypes.IMAGE_DATASET.value:
+        if self.card.metadata.data_type != AllowedTableTypes.IMAGE_DATASET.value:
             exclude_attr.add("data")
 
         storage_path = save_record_artifact_to_storage(
@@ -138,7 +138,7 @@ class DataCardArtifactSaver(CardArtifactSaver):
             storage_client=self.storage_client,
         )
 
-        self.card.uris.datacard_uri = storage_path.uri
+        self.card.metadata.uris.datacard_uri = storage_path.uri
 
     def _convert_data_to_arrow(self) -> ArrowTable:
         """Converts data to arrow table
@@ -160,7 +160,7 @@ class DataCardArtifactSaver(CardArtifactSaver):
         Returns:
             StoragePath
         """
-        self._set_storage_spec(filename=self.card.name, uri=self.card.uris.data_uri)
+        self._set_storage_spec(filename=self.card.name, uri=self.card.metadata.uris.data_uri)
 
         storage_path = save_record_artifact_to_storage(
             artifact=data,
@@ -175,22 +175,22 @@ class DataCardArtifactSaver(CardArtifactSaver):
         if isinstance(self.card.data, ImageDataset):
             self.card.data.convert_metadata()
             storage_path = self._save_data_to_storage(data=self.card.data)
-            self.card.uris.data_uri = storage_path.uri
-            self.card.data_type = AllowedTableTypes.IMAGE_DATASET.value
+            self.card.metadata.uris.data_uri = storage_path.uri
+            self.card.metadata.data_type = AllowedTableTypes.IMAGE_DATASET.value
 
         else:
             arrow_table: ArrowTable = self._convert_data_to_arrow()
             storage_path = self._save_data_to_storage(data=arrow_table.table)
-            self.card.uris.data_uri = storage_path.uri
-            self.card.feature_map = arrow_table.feature_map
-            self.card.data_type = arrow_table.table_type
+            self.card.metadata.uris.data_uri = storage_path.uri
+            self.card.metadata.feature_map = arrow_table.feature_map
+            self.card.metadata.data_type = arrow_table.table_type
 
     def _save_profile(self):
         """Saves a datacard data profile"""
 
         self._set_storage_spec(
             filename=SaveName.DATA_PROFILE.value,
-            uri=self.card.uris.profile_uri,
+            uri=self.card.metadata.uris.profile_uri,
         )
 
         # profile report needs to be dumped to bytes and saved in joblib/pickle format
@@ -210,7 +210,7 @@ class DataCardArtifactSaver(CardArtifactSaver):
         filename = f"{self.card.name}-{self.card.version}-profile.html"
         self._set_storage_spec(
             filename=filename,
-            uri=self.card.uris.profile_html_uri,
+            uri=self.card.metadata.uris.profile_html_uri,
         )
 
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -223,7 +223,7 @@ class DataCardArtifactSaver(CardArtifactSaver):
                 write_path=write_path,
             )
 
-        self.card.uris.profile_html_uri = storage_uri
+        self.card.metadata.uris.profile_html_uri = storage_uri
 
     def save_artifacts(self):
         """Saves artifacts from a DataCard"""

--- a/opsml/registry/cards/card_saver.py
+++ b/opsml/registry/cards/card_saver.py
@@ -202,7 +202,7 @@ class DataCardArtifactSaver(CardArtifactSaver):
             storage_client=self.storage_client,
         )
 
-        self.card.uris.profile_uri = storage_path.uri
+        self.card.metadata.uris.profile_uri = storage_path.uri
 
     def _save_profile_html(self):
         """Saves a profile report to file system"""

--- a/opsml/registry/cards/card_saver.py
+++ b/opsml/registry/cards/card_saver.py
@@ -254,37 +254,37 @@ class ModelCardArtifactSaver(CardArtifactSaver):
 
         return ModelMetadata(
             model_name=self.card.name,
-            model_type=self.card.model_type,
+            model_type=self.card.metadata.model_type,
             onnx_uri=onnx_attr.onnx_path,
             onnx_version=onnx_attr.onnx_version,
-            model_uri=self.card.uris.trained_model_uri,
+            model_uri=self.card.metadata.uris.trained_model_uri,
             model_version=self.card.version,
             model_team=self.card.team,
             sample_data=self.card._get_sample_data_for_api(),  # pylint: disable=protected-access
-            data_schema=self.card.data_schema,
+            data_schema=self.card.metadata.data_schema,
         )
 
     def _save_onnx_model(self) -> OnnxAttr:
         self._set_storage_spec(
             filename=SaveName.ONNX_MODEL.value,
-            uri=self.card.uris.onnx_model_uri,
+            uri=self.card.metadata.uris.onnx_model_uri,
         )
 
         self.card._create_and_set_model_attr()  # pylint: disable=protected-access
 
         if self.card.to_onnx:
             storage_path = save_record_artifact_to_storage(
-                artifact=self.card.onnx_model_def.model_bytes,
+                artifact=self.card.metadata.onnx_model_def.model_bytes,
                 artifact_type=ArtifactStorageType.ONNX.value,
                 storage_client=self.storage_client,
                 extra_path="onnx",
             )
 
-            self.card.uris.onnx_model_uri = storage_path.uri
+            self.card.metadata.uris.onnx_model_uri = storage_path.uri
 
             return OnnxAttr(
                 onnx_path=storage_path.uri,
-                onnx_version=self.card.onnx_model_def.onnx_version,
+                onnx_version=self.card.metadata.onnx_model_def.onnx_version,
             )
         return OnnxAttr()
 
@@ -295,7 +295,7 @@ class ModelCardArtifactSaver(CardArtifactSaver):
 
         self._set_storage_spec(
             filename=SaveName.MODEL_METADATA.value,
-            uri=self.card.uris.model_metadata_uri,
+            uri=self.card.metadata.uris.model_metadata_uri,
         )
 
         model_metadata = self._get_model_metadata(onnx_attr=onnx_attr)
@@ -306,54 +306,56 @@ class ModelCardArtifactSaver(CardArtifactSaver):
             storage_client=self.storage_client,
         )
 
-        self.card.uris.model_metadata_uri = metadata_path.uri
+        self.card.metadata.uris.model_metadata_uri = metadata_path.uri
 
     def _save_modelcard(self):
         """Saves a modelcard to file system"""
 
         self._set_storage_spec(
             filename=SaveName.MODELCARD.value,
-            uri=self.card.uris.modelcard_uri,
+            uri=self.card.metadata.uris.modelcard_uri,
         )
 
+        model_dump = self.card.model_dump(
+            exclude={
+                "sample_input_data",
+                "trained_model",
+                "storage_client",
+            }
+        )
+        model_dump["metadata"].pop("onnx_model_def")
+
         storage_path = save_record_artifact_to_storage(
-            artifact=self.card.model_dump(
-                exclude={
-                    "sample_input_data",
-                    "trained_model",
-                    "storage_client",
-                    "onnx_model_def",
-                }
-            ),
+            artifact=model_dump,
             storage_client=self.storage_client,
         )
 
-        self.card.uris.modelcard_uri = storage_path.uri
+        self.card.metadata.uris.modelcard_uri = storage_path.uri
 
     def _save_trained_model(self):
         """Saves trained model associated with ModelCard to filesystem"""
 
         self._set_storage_spec(
             filename=SaveName.TRAINED_MODEL.value,
-            uri=self.card.uris.trained_model_uri,
+            uri=self.card.metadata.uris.trained_model_uri,
         )
 
         self.storage_spec.sample_data = self.card.sample_input_data
 
         storage_path = save_record_artifact_to_storage(
             artifact=self.card.trained_model,
-            artifact_type=self.card.model_type,
+            artifact_type=self.card.metadata.model_type,
             storage_client=self.storage_client,
             extra_path="model",
         )
-        self.card.uris.trained_model_uri = storage_path.uri
+        self.card.metadata.uris.trained_model_uri = storage_path.uri
 
     def _save_sample_data(self) -> None:
         """Saves sample data associated with ModelCard to filesystem"""
 
         self._set_storage_spec(
             filename=SaveName.SAMPLE_MODEL_DATA.value,
-            uri=self.card.uris.sample_data_uri,
+            uri=self.card.metadata.uris.sample_data_uri,
         )
 
         if isinstance(self.card.sample_input_data, dict):
@@ -361,7 +363,7 @@ class ModelCardArtifactSaver(CardArtifactSaver):
                 artifact=self.card.sample_input_data,
                 storage_client=self.storage_client,
             )
-            self.card.sample_data_type = AllowedTableTypes.DICTIONARY.value
+            self.card.metadata.sample_data_type = AllowedTableTypes.DICTIONARY.value
 
         else:
             arrow_table: ArrowTable = DataFormatter.convert_data_to_arrow(data=self.card.sample_input_data)
@@ -369,14 +371,14 @@ class ModelCardArtifactSaver(CardArtifactSaver):
                 artifact=arrow_table.table,
                 storage_client=self.storage_client,
             )
-            self.card.sample_data_type = arrow_table.table_type
+            self.card.metadata.sample_data_type = arrow_table.table_type
 
-        self.card.uris.sample_data_uri = storage_path.uri
+        self.card.metadata.uris.sample_data_uri = storage_path.uri
 
     def save_artifacts(self):
         """Save model artifacts associated with ModelCard"""
 
-        if self.card.uris.model_metadata_uri is None:
+        if self.card.metadata.uris.model_metadata_uri is None:
             self._save_model_metadata()
 
         self._save_modelcard()

--- a/opsml/registry/cards/data.py
+++ b/opsml/registry/cards/data.py
@@ -17,7 +17,7 @@ from opsml.helpers.utils import (
 )
 from opsml.profile.profile_data import DataProfiler, ProfileReport
 from opsml.registry.cards.base import ArtifactCard
-from opsml.registry.cards.types import CardType, DataCardUris
+from opsml.registry.cards.types import CardType
 from opsml.registry.image import ImageDataset
 from opsml.registry.data.splitter import DataHolder, DataSplit, DataSplitter
 from opsml.registry.storage.storage_system import StorageClientType
@@ -96,6 +96,7 @@ class DataCard(ArtifactCard):
     data_splits: List[DataSplit] = []
     dependent_vars: Optional[List[Union[int, str]]] = None
     sql_logic: Dict[Optional[str], Optional[str]] = {}
+    data_profile: Optional[ProfileReport] = None
     metadata: DataCardMetadata = DataCardMetadata()
 
     @field_validator("metadata", mode="before")
@@ -222,8 +223,7 @@ class DataCard(ArtifactCard):
                 to add to the current metadata set
         """
 
-        curr_info = cast(Dict[str, Union[int, float, str]], self.metadata.additional_info)
-        self.metadata.additional_info = {**info, **curr_info}
+        self.metadata.additional_info = {**info, **self.metadata.additional_info}
 
     def add_sql(
         self,

--- a/opsml/registry/cards/data.py
+++ b/opsml/registry/cards/data.py
@@ -2,7 +2,7 @@
 # Copyright (c) Shipt, Inc.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Dict, List, Optional, Union, cast
 import os
 import numpy as np
 import pandas as pd

--- a/opsml/registry/cards/data.py
+++ b/opsml/registry/cards/data.py
@@ -52,36 +52,13 @@ class DataCard(ArtifactCard):
         user_email:
             Email to associate with data card
         dependent_vars:
-            Optional list of dependent variables in data
-        dependent_vars:
             List of dependent variables. Can be string or index if using numpy
-        feature_descriptions:
-            Dictionary of features and their descriptions
-        additional_info:
-            Dictionary of additional info to associate with data
-            (i.e. if data is tokenized dataset, metadata could be {"vocab_size": 200})
         data_splits:
             Optional list of `DataSplit`
-
-        runcard_uid:
-            Id of RunCard that created the DataCard
-
-        pipelinecard_uid:
-            Associated PipelineCard
-
         sql_logic:
             Dictionary of strings containing sql logic or sql files used to create the data
-
-        The following are non-required args and are set after registering a DataCard
-
-        data_uri:
-            Location where converted pyarrow table is stored
         version:
             DataCard version
-        feature_map:
-            Map of features in data (inferred when converting to pyarrow table)
-        data_type:
-            Data type inferred from supplied data
         uid:
             Unique id assigned to the DataCard
         data_profile:

--- a/opsml/registry/cards/model.py
+++ b/opsml/registry/cards/model.py
@@ -62,29 +62,10 @@ class ModelCard(ArtifactCard):
             Current version (assigned if card has been registered)
         datacard_uid:
             Uid of the DataCard associated with training the model
-        onnx_model_data:
-            Pydantic model containing onnx data schema
-        onnx_model_def:
-            Pydantic model containing OnnxModel definition
-        model_type:
-            Type of model
-        data_schema:
-            Optional dictionary of the data schema used in model training
-        additional_onnx_args:
-            Optional pydantic model containing Torch args for model conversion to onnx.
-        runcard_uid:
-            RunCard associated with the ModelCard
-        pipelinecard_uid:
-            Associated PipelineCard
-        uris:
-            modelcard_uri:
-                URI of modelcard
-            trained_model_uri:
-                URI where model is stored
-            sample_data_uri:
-                URI of trained model sample data
-            model_metadata_uri:
-                URI where model metadata is stored
+        to_onnx:
+            Whether to convert the model to onnx or not
+        metadata:
+            `ModelCardMetadata` associated with the model
     """
 
     model_config = ConfigDict(

--- a/opsml/registry/cards/types.py
+++ b/opsml/registry/cards/types.py
@@ -12,17 +12,6 @@ logger = ArtifactLogger.get_logger(__name__)
 
 
 @dataclass
-class ModelCardUris:
-    modelcard_uri: Optional[str] = None
-    trained_model_uri: Optional[str] = None
-    onnx_model_uri: Optional[str] = None
-    model_metadata_uri: Optional[str] = None
-    sample_data_uri: Optional[str] = None
-
-    model_config = ConfigDict(protected_namespaces=("protect_",))
-
-
-@dataclass
 class DataCardUris:
     data_uri: Optional[str] = None
     datacard_uri: Optional[str] = None

--- a/opsml/registry/cards/types.py
+++ b/opsml/registry/cards/types.py
@@ -5,18 +5,10 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List, Optional, Union
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel
 from opsml.helpers.logging import ArtifactLogger
 
 logger = ArtifactLogger.get_logger(__name__)
-
-
-@dataclass
-class DataCardUris:
-    data_uri: Optional[str] = None
-    datacard_uri: Optional[str] = None
-    profile_uri: Optional[str] = None
-    profile_html_uri: Optional[str] = None
 
 
 class Metric(BaseModel):

--- a/opsml/registry/data/formatter.py
+++ b/opsml/registry/data/formatter.py
@@ -33,7 +33,8 @@ class PolarsFormatter(ArrowFormatter):
         """Convert pandas dataframe to pyarrow table
 
         Args:
-            data (polar dataframe): Polar dataframe
+            data:
+                Polar dataframe
 
         Returns
             ArrowTable pydantic class containing table and table type
@@ -55,7 +56,8 @@ class PandasFormatter(ArrowFormatter):
         """Convert pandas dataframe to pyarrow table
 
         Args:
-            data (pd.DataFrame): Pandas dataframe to convert
+            data:
+                Pandas dataframe to convert
 
         Returns
             ArrowTable pydantic class containing table and table type

--- a/opsml/registry/data/types.py
+++ b/opsml/registry/data/types.py
@@ -44,15 +44,15 @@ class DataCardMetadata(BaseModel):
     description: Optional[str] = None
     feature_map: Optional[Dict[str, Optional[Any]]] = None
     data_type: Optional[str] = None
-    feature_descriptions: Optional[Dict[str, str]] = None
-    additional_info: Optional[Dict[str, Union[float, int, str]]] = None
+    feature_descriptions: Dict[str, str] = {}
+    additional_info: Dict[str, Union[float, int, str]] = {}
     runcard_uid: Optional[str] = None
     pipelinecard_uid: Optional[str] = None
     uris: DataCardUris = DataCardUris()
 
     @field_validator("feature_descriptions", mode="before")
     def lower_descriptions(cls, feature_descriptions):
-        if feature_descriptions is None:
+        if not bool(feature_descriptions):
             return feature_descriptions
 
         feat_dict = {}

--- a/opsml/registry/data/types.py
+++ b/opsml/registry/data/types.py
@@ -1,16 +1,25 @@
 # Copyright (c) Shipt, Inc.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, Optional, Union, Any, Mapping
 
 import numpy as np
 import pyarrow as pa
 from polars.datatypes.classes import DataType, DataTypeClass
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
 POLARS_SCHEMA = Mapping[str, Union[DataTypeClass, DataType]]  # pylint: disable=invalid-name
+
+
+@dataclass
+class DataCardUris:
+    data_uri: Optional[str] = None
+    datacard_uri: Optional[str] = None
+    profile_uri: Optional[str] = None
+    profile_html_uri: Optional[str] = None
 
 
 class AllowedTableTypes(str, Enum):
@@ -29,3 +38,24 @@ class ArrowTable(BaseModel):
     table_type: AllowedTableTypes
     storage_uri: Optional[str] = None
     feature_map: Optional[Union[Dict[str, Any], POLARS_SCHEMA]] = None
+
+
+class DataCardMetadata(BaseModel):
+    description: Optional[str] = None
+    feature_map: Optional[Dict[str, Optional[Any]]] = None
+    data_type: Optional[str] = None
+    feature_descriptions: Optional[Dict[str, str]] = None
+    additional_info: Optional[Dict[str, Union[float, int, str]]] = None
+    runcard_uid: Optional[str] = None
+    pipelinecard_uid: Optional[str] = None
+    uris: DataCardUris = DataCardUris()
+
+    @field_validator("feature_descriptions", mode="before")
+    def lower_descriptions(cls, feature_descriptions):
+        if feature_descriptions is None:
+            return feature_descriptions
+
+        feat_dict = {}
+        for feature, description in feature_descriptions.items():
+            feat_dict[feature.lower()] = description.lower()
+            return feat_dict

--- a/opsml/registry/data/types.py
+++ b/opsml/registry/data/types.py
@@ -16,6 +16,19 @@ POLARS_SCHEMA = Mapping[str, Union[DataTypeClass, DataType]]  # pylint: disable=
 
 @dataclass
 class DataCardUris:
+    """Data uri holder for DataCardMetadata
+
+    Args:
+        data_uri:
+            Location where converted data is stored
+        datacard_uri:
+            Location where DataCard is stored
+        profile_uri:
+            Location where profile is stored
+        profile_html_uri:
+            Location where profile html is stored
+    """
+
     data_uri: Optional[str] = None
     datacard_uri: Optional[str] = None
     profile_uri: Optional[str] = None
@@ -41,6 +54,29 @@ class ArrowTable(BaseModel):
 
 
 class DataCardMetadata(BaseModel):
+
+    """Create a DataCard metadata
+
+    Args:
+        description:
+            Description for your data
+        feature_map:
+            Map of features in data (inferred when converting to pyarrow table)
+        feature_descriptions:
+            Dictionary of features and their descriptions
+        additional_info:
+            Dictionary of additional info to associate with data
+            (i.e. if data is tokenized dataset, metadata could be {"vocab_size": 200})
+        data_uri:
+            Location where converted pyarrow table is stored
+        runcard_uid:
+            Id of RunCard that created the DataCard
+        pipelinecard_uid:
+            Associated PipelineCard
+        uris:
+            DataCardUris object containing all uris associated with DataCard
+    """
+
     description: Optional[str] = None
     feature_map: Optional[Dict[str, Optional[Any]]] = None
     data_type: Optional[str] = None

--- a/opsml/registry/sql/records.py
+++ b/opsml/registry/sql/records.py
@@ -68,14 +68,16 @@ class ModelRegistryRecord(SaveRecord):
     model_config = ConfigDict(protected_namespaces=("protect_",))
 
     @model_validator(mode="before")
-    def set_uris(cls, values):
+    def set_metadata(cls, values):
         metadata = values.get("metadata")
+        values["modelcard_uri"] = metadata["uris"]["modelcard_uri"]
         values["trained_model_uri"] = metadata["uris"]["trained_model_uri"]
         values["model_metadata_uri"] = metadata["uris"]["model_metadata_uri"]
         values["sample_data_uri"] = metadata["uris"]["sample_data_uri"]
-        values["modelcard_uri"] = metadata["uris"]["modelcard_uri"]
         values["sample_data_type"] = metadata["sample_data_type"]
         values["model_type"] = metadata["model_type"]
+        values["runcard_uid"] = metadata["runcard_uid"]
+        values["pipelinecard_uid"] = metadata["pipelinecard_uid"]
 
         return values
 

--- a/opsml/registry/storage/download.py
+++ b/opsml/registry/storage/download.py
@@ -6,8 +6,7 @@ from opsml.registry.storage.artifact_storage import load_record_artifact_from_st
 from opsml.registry.storage.storage_system import StorageClientType
 from opsml.registry.data.formatter import check_data_schema
 from opsml.registry.storage.types import ArtifactStorageSpecs
-from opsml.registry.data.types import AllowedTableTypes
-from opsml.registry.cards.types import DataCardUris
+from opsml.registry.data.types import AllowedTableTypes, DataCardUris
 from opsml.registry.image import ImageDataset
 from opsml.registry.cards import ArtifactCard
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,6 @@ import lightgbm as lgb
 
 # opsml
 from opsml.registry.data.splitter import DataSplit
-from opsml.registry.cards.types import ModelCardUris
 from opsml.registry import ModelCard
 from opsml.helpers.gcp_utils import GcpCreds, GCSStorageClient
 from opsml.helpers.request_helpers import ApiClient
@@ -84,7 +83,7 @@ from opsml.projects.mlflow import MlflowProject
 from opsml.projects.base.types import ProjectInfo
 from opsml.registry import CardRegistries
 from opsml.projects import OpsmlProject
-from opsml.model.types import OnnxModelDefinition
+from opsml.model.types import OnnxModelDefinition, ModelCardUris
 
 # testing
 from tests.mock_api_registries import CardRegistry as ClientCardRegistry

--- a/tests/test_app/test_client.py
+++ b/tests/test_app/test_client.py
@@ -12,7 +12,17 @@ from numpy.typing import NDArray
 from pydantic import ValidationError
 from requests.auth import HTTPBasicAuth
 
-from opsml.registry import DataCard, ModelCard, RunCard, PipelineCard, CardRegistry, CardRegistries, CardInfo
+from opsml.registry import (
+    DataCard,
+    ModelCard,
+    RunCard,
+    PipelineCard,
+    CardRegistry,
+    CardRegistries,
+    CardInfo,
+    DataCardMetadata,
+    ModelCardMetadata,
+)
 from opsml.helpers.request_helpers import ApiRoutes
 from opsml.app.core import config
 from tests.conftest import TODAY_YMD
@@ -247,7 +257,7 @@ def test_register_model(
     )
 
     model_registry.register_card(card=model_card_custom)
-    assert "pipeline-model" in model_card_custom.uris.trained_model_uri
+    assert "pipeline-model" in model_card_custom.metadata.uris.trained_model_uri
 
     model_card2 = ModelCard(
         trained_model=model,
@@ -325,7 +335,7 @@ def test_load_data_card(api_registries: CardRegistries, test_data: pd.DataFrame)
         team=team,
         user_email=user_email,
         data_splits=data_split,
-        additional_info={"input_metadata": 20},
+        metadata=DataCardMetadata(additional_info={"input_metadata": 20}),
         dependent_vars=[200, "test"],
     )
 
@@ -335,8 +345,8 @@ def test_load_data_card(api_registries: CardRegistries, test_data: pd.DataFrame)
 
     loaded_data.load_data()
 
-    assert int(loaded_data.additional_info["input_metadata"]) == 20
-    assert int(loaded_data.additional_info["added_metadata"]) == 10
+    assert int(loaded_data.metadata.additional_info["input_metadata"]) == 20
+    assert int(loaded_data.metadata.additional_info["added_metadata"]) == 10
     assert isinstance(loaded_data.dependent_vars[0], int)
     assert isinstance(loaded_data.dependent_vars[1], str)
     assert bool(loaded_data)
@@ -355,13 +365,13 @@ def test_load_data_card(api_registries: CardRegistries, test_data: pd.DataFrame)
             team=team,
             user_email=user_email,
             data_splits=data_split,
-            additional_info={"input_metadata": 20},
+            metadata=DataCardMetadata(additional_info={"input_metadata": 20}),
             dependent_vars=[200, "test"],
         )
 
     # load card again
     datacardv12: DataCard = registry.load_card(name=data_name, version="1.2.0")
-    datacardv12.uris.data_uri = "fail"
+    datacardv12.metadata.uris.data_uri = "fail"
 
     with pytest.raises(FileNotFoundError):
         datacardv12.load_data()
@@ -582,7 +592,7 @@ def test_model_metrics(
         sample_input_data=data[0:1],
         info=card_info,
         datacard_uid=datacard.uid,
-        runcard_uid=runcard.uid,
+        metadata=ModelCardMetadata(runcard_uid=runcard.uid),
     )
     api_registries.model.register_card(modelcard)
 
@@ -593,7 +603,7 @@ def test_model_metrics(
         sample_input_data=data[0:1],
         info=card_info,
         datacard_uid=datacard.uid,
-        runcard_uid=runcard.uid,
+        metadata=ModelCardMetadata(runcard_uid=runcard.uid),
     )
     api_registries.model.register_card(modelcard_2)
 

--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -2,7 +2,7 @@ from typing import Tuple
 from typer.testing import CliRunner
 from sklearn import linear_model
 import pandas as pd
-from opsml.registry import DataCard, ModelCard, CardRegistries, RunCard, CardInfo
+from opsml.registry import DataCard, ModelCard, CardRegistries, RunCard, CardInfo, ModelCardMetadata
 import tempfile
 from opsml.cli.api_cli import app
 from sklearn import pipeline
@@ -185,7 +185,7 @@ def test_model_metrics(
         sample_input_data=data[0:1],
         info=card_info,
         datacard_uid=datacard.uid,
-        runcard_uid=runcard.uid,
+        metadata=ModelCardMetadata(runcard_uid=runcard.uid),
     )
     api_registries.model.register_card(modelcard)
 
@@ -214,7 +214,7 @@ def test_model_metrics(
         sample_input_data=data[0:1],
         info=card_info,
         datacard_uid=datacard.uid,
-        runcard_uid=runcard.uid,
+        metadata=ModelCardMetadata(runcard_uid=runcard.uid),
     )
     api_registries.model.register_card(challenger)
 

--- a/tests/test_model/test_onnx.py
+++ b/tests/test_model/test_onnx.py
@@ -1,11 +1,10 @@
 import sys
 
-from opsml.registry.cards import ModelCard
+from opsml.registry.cards import ModelCard, ModelCardMetadata
 import numpy as np
 import pytest
 import pandas as pd
 from pytest_lazyfixture import lazy_fixture
-from opsml.model.types import ModelMetadata
 import warnings
 
 
@@ -191,10 +190,10 @@ def test_byo_onnx(model_and_data):
         name="test_model",
         team="mlops",
         user_email="test_email",
-        datacard_uids=["test_uid"],
+        datacard_uid="test_uid",
     )
     predictor = modelcard.onnx_model()
-    model_def = modelcard.onnx_model_def
+    model_def = modelcard.metadata.onnx_model_def
 
     # byo onnx model def
     new_modelcard = ModelCard(
@@ -203,11 +202,11 @@ def test_byo_onnx(model_and_data):
         name="test_model",
         team="mlops",
         user_email="test_email",
-        datacard_uids=["test_uid"],
-        onnx_model_def=model_def,
+        datacard_uid="test_uid",
+        metadata=ModelCardMetadata(onnx_model_def=model_def),
     )
     predictor = new_modelcard.onnx_model()
-    assert new_modelcard.data_schema is not None
+    assert new_modelcard.metadata.data_schema is not None
 
     if isinstance(data, np.ndarray):
         input_name = next(iter(predictor.data_schema.model_data_schema.input_features.keys()))
@@ -245,8 +244,8 @@ def test_byo_pytorch_onnx(model_and_data):
         name="test_model",
         team="mlops",
         user_email="test_email",
-        datacard_uids=["test_uid"],
-        onnx_model_def=model_def,
+        datacard_uid="test_uid",
+        metadata=ModelCardMetadata(onnx_model_def=model_def),
     )
     predictor = modelcard.onnx_model()
     input_name = next(iter(predictor.data_schema.model_data_schema.input_features.keys()))

--- a/tests/test_profile/test_data_profiler.py
+++ b/tests/test_profile/test_data_profiler.py
@@ -32,7 +32,7 @@ def test_datacard_create_data_profile_pandas(
 
     registry.register_card(data_card)
 
-    assert data_card.uris.profile_uri is not None
+    assert data_card.metadata.uris.profile_uri is not None
 
     data_card = registry.load_card(uid=data_card.uid)
 
@@ -63,7 +63,7 @@ def test_datacard_create_data_profile_polars(
 
     registry.register_card(data_card)
 
-    assert data_card.uris.profile_uri is not None
+    assert data_card.metadata.uris.profile_uri is not None
 
     data_card = registry.load_card(uid=data_card.uid)
 

--- a/tests/test_projects/test_challenger.py
+++ b/tests/test_projects/test_challenger.py
@@ -97,7 +97,7 @@ def test_challenger_champion_list(opsml_project: OpsmlProject) -> None:
     """Test ModelChallenger using champion list"""
 
     modelcard = opsml_project._run_mgr.registries.model.load_card(name="pipeline_model", version="1.1.0")
-    runcard = opsml_project._run_mgr.registries.run.load_card(uid=modelcard.runcard_uid)
+    runcard = opsml_project._run_mgr.registries.run.load_card(uid=modelcard.metadata.runcard_uid)
 
     challenger = ModelChallenger(challenger=modelcard)
 
@@ -166,7 +166,7 @@ def test_challenger_fail_no_runcard(
 
     # run test
     modelcard = opsml_project._run_mgr.registries.model.load_card(name="pipeline_model", version="1.1.0")
-    runcard = opsml_project._run_mgr.registries.run.load_card(uid=modelcard.runcard_uid)
+    runcard = opsml_project._run_mgr.registries.run.load_card(uid=modelcard.metadata.runcard_uid)
 
     challenger = ModelChallenger(challenger=modelcard)
 

--- a/tests/test_projects/test_opsml_project.py
+++ b/tests/test_projects/test_opsml_project.py
@@ -50,7 +50,7 @@ def test_opsml_read_only(opsml_project: OpsmlProject, sklearn_pipeline: tuple[pi
         run.log_artifact(name="array", artifact=array)
         info.run_id = run.run_id
 
-        assert data_card.runcard_uid == run.run_id
+        assert data_card.metadata.runcard_uid == run.run_id
 
     # Retrieve the run and load projects without making the run active (read only mode)
     proj = conftest.mock_opsml_project(info)
@@ -79,7 +79,7 @@ def test_opsml_read_only(opsml_project: OpsmlProject, sklearn_pipeline: tuple[pi
     )
     assert loaded_data_card.uid is not None
     assert loaded_data_card.uid == data_card.uid
-    assert loaded_data_card.runcard_uid == proj.run_id
+    assert loaded_data_card.metadata.runcard_uid == proj.run_id
 
     # load data
     assert loaded_data_card.data is None

--- a/tests/test_registry/test_registry.py
+++ b/tests/test_registry/test_registry.py
@@ -502,7 +502,7 @@ def test_local_model_registry_to_onnx(
     model_registry.register_card(card=model_card)
 
     loaded_card = model_registry.load_card(uid=model_card.uid)
-    assert loaded_card.uris.model_metadata_uri is not None
+    assert loaded_card.metadata.uris.model_metadata_uri is not None
 
 
 def test_local_model_registry_no_onnx(
@@ -534,7 +534,7 @@ def test_local_model_registry_no_onnx(
     model_registry.register_card(card=model_card)
 
     loaded_card = model_registry.load_card(uid=model_card.uid)
-    assert loaded_card.uris.model_metadata_uri is not None
+    assert loaded_card.metadata.uris.model_metadata_uri is not None
 
 
 def test_local_model_registry(
@@ -576,14 +576,14 @@ def test_local_model_registry(
     model_registry: CardRegistry = db_registries["model"]
     model_registry.register_card(model_card)
 
-    assert path.exists(model_card.uris.model_metadata_uri)
-    assert path.exists(model_card.uris.trained_model_uri)
-    assert path.exists(model_card.uris.sample_data_uri)
+    assert path.exists(model_card.metadata.uris.model_metadata_uri)
+    assert path.exists(model_card.metadata.uris.trained_model_uri)
+    assert path.exists(model_card.metadata.uris.sample_data_uri)
 
-    loaded_card = model_registry.load_card(uid=model_card.uid)
+    loaded_card: ModelCard = model_registry.load_card(uid=model_card.uid)
 
     assert loaded_card != model_card
-    assert loaded_card.onnx_model_def is None
+    assert loaded_card.metadata.onnx_model_def is None
     assert loaded_card.trained_model is None
     assert loaded_card.sample_input_data is None
 
@@ -592,7 +592,7 @@ def test_local_model_registry(
 
     assert loaded_card.trained_model is not None
     assert loaded_card.sample_input_data is not None
-    assert loaded_card.onnx_model_def is not None
+    assert loaded_card.metadata.onnx_model_def is not None
 
 
 def test_register_model(
@@ -883,7 +883,7 @@ def test_model_registry_with_polars(
     model_registry.register_card(card=model_card)
 
     loaded_card = model_registry.load_card(uid=model_card.uid)
-    assert loaded_card.uris.model_metadata_uri is not None
+    assert loaded_card.metadata.uris.model_metadata_uri is not None
 
 
 def test_pandas_dtypes(db_registries: Dict[str, CardRegistry], drift_dataframe):

--- a/tests/test_registry/test_registry.py
+++ b/tests/test_registry/test_registry.py
@@ -7,7 +7,15 @@ import pyarrow as pa
 from os import path
 import pytest
 from pytest_lazyfixture import lazy_fixture
-from opsml.registry.cards import DataCard, RunCard, PipelineCard, ModelCard, DataSplit, DataCardMetadata
+from opsml.registry.cards import (
+    DataCard,
+    RunCard,
+    PipelineCard,
+    ModelCard,
+    DataSplit,
+    DataCardMetadata,
+    ModelCardMetadata,
+)
 from opsml.registry.sql.registry import CardRegistry
 from opsml.helpers.exceptions import VersionError
 from sklearn import linear_model
@@ -620,6 +628,7 @@ def test_register_model(
         team="mlops",
         user_email="mlops.com",
         datacard_uid=data_card.uid,
+        metadata=ModelCardMetadata(description="test description"),
     )
 
     model_registry: CardRegistry = db_registries["model"]
@@ -633,6 +642,7 @@ def test_register_model(
 
     assert getattr(loaded_card, "trained_model") is not None
     assert getattr(loaded_card, "sample_input_data") is not None
+    assert loaded_card.metadata.description == "test description"
 
     model_card_custom = ModelCard(
         trained_model=model,
@@ -723,6 +733,7 @@ def test_load_data_card(db_registries: Dict[str, CardRegistry], test_data: pd.Da
         data_splits=data_split,
         metadata=DataCardMetadata(
             additional_info={"input_metadata": 20},
+            description="test description",
         ),
         dependent_vars=[200, "test"],
         sql_logic={"test": "SELECT * FROM TEST_TABLE"},
@@ -737,6 +748,7 @@ def test_load_data_card(db_registries: Dict[str, CardRegistry], test_data: pd.Da
 
     assert int(loaded_data.metadata.additional_info["input_metadata"]) == 20
     assert int(loaded_data.metadata.additional_info["added_metadata"]) == 10
+    assert loaded_data.metadata.description == "test description"
     assert isinstance(loaded_data.dependent_vars[0], int)
     assert isinstance(loaded_data.dependent_vars[1], str)
     assert bool(loaded_data)


### PR DESCRIPTION
## Pull Request

### Short Summary
Reduces clutter in `ModelCard` and `DataCard` attributes

### Context
`ModelCard` and `DataCard` have too many attributes that can more broadly be defined as `metadata`. This PR introduces a `ModelCardMetadata` and `DataCardMetadata` class that are used in the new attr `metadata`.  This will allow both model and data cards to have a simpler public interface

### Is this a Breaking Change?
Could be. The attrs that have been moved to `metadata` are attrs that are not regularly accessed or used by users. However, because the public interface is changing, we will need to announce it when the release is made

