### PR TITLE
allow path-like object

### DIFF
--- a/opsml/projects/mlflow/_active_run.py
+++ b/opsml/projects/mlflow/_active_run.py
@@ -3,6 +3,7 @@
 # LICENSE file in the root directory of this source tree.
 from typing import Dict, Optional, Union, cast
 from pathlib import Path
+import os
 from opsml.projects.base._active_run import ActiveRun
 from opsml.projects.mlflow.mlflow_utils import MlflowRunInfo
 from opsml.registry.cards.types import METRICS, PARAMS
@@ -99,7 +100,7 @@ class MlflowActiveRun(ActiveRun):
         super().log_parameter(key, value)
         self.info.mlflow_client.log_param(run_id=self.run_id, key=key, value=value)
 
-    def log_artifact_from_file(self, local_path: Union[Path, str], artifact_path: Optional[str] = None) -> None:
+    def log_artifact_from_file(self, local_path: Union[os.PathLike, str], artifact_path: Optional[str] = None) -> None:
         """
         Logs an artifact for the current run. All artifacts are loaded
         to a parent directory named "misc".
@@ -124,7 +125,7 @@ class MlflowActiveRun(ActiveRun):
             artifact_path=_artifact_path,
         )
 
-        filename = local_path.name if isinstance(local_path, Path) else Path(local_path).name
+        filename = local_path.name if isinstance(local_path, os.PathLike) else Path(local_path).name
         artifact_uri = f"{self.info.base_artifact_path}/{_artifact_path}/{filename}"
 
         self.runcard.add_artifact_uri(name=filename, uri=artifact_uri)

--- a/opsml/projects/mlflow/_active_run.py
+++ b/opsml/projects/mlflow/_active_run.py
@@ -2,7 +2,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 from typing import Dict, Optional, Union, cast
-
+from pathlib import Path
 from opsml.projects.base._active_run import ActiveRun
 from opsml.projects.mlflow.mlflow_utils import MlflowRunInfo
 from opsml.registry.cards.types import METRICS, PARAMS
@@ -99,14 +99,14 @@ class MlflowActiveRun(ActiveRun):
         super().log_parameter(key, value)
         self.info.mlflow_client.log_param(run_id=self.run_id, key=key, value=value)
 
-    def log_artifact_from_file(self, local_path: str, artifact_path: Optional[str] = None) -> None:
+    def log_artifact_from_file(self, local_path: Union[Path, str], artifact_path: Optional[str] = None) -> None:
         """
         Logs an artifact for the current run. All artifacts are loaded
         to a parent directory named "misc".
 
         Args:
             local_path:
-                Local path to object
+                Local path to object. Can be a string of `Path` object
             artifact_path:
                 Artifact directory path in Mlflow to log to. This path will be appended
                 to parent directory "misc"
@@ -124,7 +124,7 @@ class MlflowActiveRun(ActiveRun):
             artifact_path=_artifact_path,
         )
 
-        filename = local_path.split("/")[-1]
+        filename = local_path.name if isinstance(local_path, Path) else Path(local_path).name
         artifact_uri = f"{self.info.base_artifact_path}/{_artifact_path}/{filename}"
 
         self.runcard.add_artifact_uri(name=filename, uri=artifact_uri)

--- a/opsml/projects/mlflow/_active_run.py
+++ b/opsml/projects/mlflow/_active_run.py
@@ -125,7 +125,7 @@ class MlflowActiveRun(ActiveRun):
             artifact_path=_artifact_path,
         )
 
-        filename = local_path.name if isinstance(local_path, os.PathLike) else Path(local_path).name
+        filename = local_path.name if isinstance(local_path, Path) else Path(local_path).name
         artifact_uri = f"{self.info.base_artifact_path}/{_artifact_path}/{filename}"
 
         self.runcard.add_artifact_uri(name=filename, uri=artifact_uri)

--- a/tests/test_projects/test_mlflow.py
+++ b/tests/test_projects/test_mlflow.py
@@ -2,7 +2,7 @@ from typing import Any, cast, Dict, Tuple
 
 import os
 import sys
-
+from pathlib import Path
 import pandas as pd
 from numpy.typing import NDArray
 import pytest
@@ -183,7 +183,13 @@ def test_log_artifact(mlflow_project: MlflowProject) -> None:
         array = np.random.random((10, 10))
         fig.savefig("test.png")  # save the figure to file
         plt.close(fig)
+
+        # try string
         run.log_artifact_from_file(local_path=filename)
+
+        # try path
+        run.log_artifact_from_file(local_path=Path(filename))
+        #
         run.log_artifact("test_array", array)
         run.add_tag("test_tag", "1.0.0")
         info.run_id = run.run_id


### PR DESCRIPTION
## Pull Request

### Short Summary
Adds ability to pass `Path` object when logging an artifact from file

### Context
`log_artifact_from_file` relies on the user passing a path string. This PR allows a user to pass a `Path` object as well.

### Is this a Breaking Change?
No. Expands existing function signature (client side)

