### PR TITLE
Update creator.py

### DIFF
--- a/opsml/model/creator.py
+++ b/opsml/model/creator.py
@@ -177,8 +177,11 @@ class TrainedModelMetadataCreator(ModelCreator):
         return {"placeholder": Feature(feature_type="str", shape=[1])}
 
     def create_model(self) -> ModelReturn:
-        input_features = self._get_input_schema()
+        # make predictions first in case of column type switching for input cols
         output_features = self._get_output_schema()
+
+        # this will convert categorical to string
+        input_features = self._get_input_schema()
 
         api_schema = ApiDataSchemas(
             model_data_schema=DataDict(


### PR DESCRIPTION
## Pull Request

### Short Summary
Switches input and output api schema generation so output type inference occurs prior to input inference and prevents type mismatch error.

### Context
Input api schema generation converts categorical to strings in place which causes prediction output inference to fail due to type mismatch in data fed to model vs what is expected. This PR switch input and ouput api schema generation lines so that the correct data types are fed to the model during output type inference.

### Is this a Breaking Change?
No

