### PR TITLE
Update/calibrated classifier edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,36 @@
 
 </div>
  
+<div align="center">
+  <a href="https://keras.io/">
+    <img alt="keras"" src="https://img.shields.io/badge/Keras-FF0000?logo=keras&logoColor=white"/>
+
+  <a href="https://pytorch.org/">
+    <img alt="pytorch" src="https://img.shields.io/badge/PyTorch--EE4C2C.svg?style=flat&logo=pytorch"/>
+
+  <a href="https://scikit-learn.org/stable/">
+    <img alt="scikit-learn" src="https://img.shields.io/badge/scikit_learn-F7931E?logo=scikit-learn&logoColor=white"/>
+
+
+  <a href="https://xgboost.readthedocs.io/en/stable/">
+    <img alt="xgboost" src=https://img.shields.io/badge/Package-XGBoost-blueviolet"/>
+
+
+  <a href="https://lightgbm.readthedocs.io/en/v3.3.2/">
+    <img alt="lightgbm" src=https://img.shields.io/badge/Package-LightGBM-success"/>
+</div>
+
+<h4 align="left">Supported Storage Types</h4>
+
+<div align="center">
+  <a href="https://cloud.google.com/storage">
+    <img alt="google cloud" src="https://img.shields.io/badge/google_cloud_storage-grey.svg?logo=google-cloud"/>
+  </a>
+
+  <a href="https://cloud.google.com/storage">
+    <img alt="google cloud" src="https://img.shields.io/badge/aws_s3-grey?logo=amazons3"/>
+  </a>
+</div>
 
 
 
@@ -109,29 +139,5 @@ Thanks goes to these phenomenal [projects and people](./ATTRIBUTIONS.md) and peo
 
 
 
-<a href="https://keras.io/">
-  <img alt="keras"" src="https://img.shields.io/badge/Keras-FF0000?logo=keras&logoColor=white"/>
 
-<a href="https://pytorch.org/">
-  <img alt="pytorch" src="https://img.shields.io/badge/PyTorch--EE4C2C.svg?style=flat&logo=pytorch"/>
-
-<a href="https://scikit-learn.org/stable/">
-  <img alt="scikit-learn" src="https://img.shields.io/badge/scikit_learn-F7931E?logo=scikit-learn&logoColor=white"/>
-
-
-<a href="https://xgboost.readthedocs.io/en/stable/">
-  <img alt="xgboost" src=https://img.shields.io/badge/Package-XGBoost-blueviolet"/>
-
-
-<a href="https://lightgbm.readthedocs.io/en/v3.3.2/">
-  <img alt="lightgbm" src=https://img.shields.io/badge/Package-LightGBM-success"/>
-
-<h4 align="left">Supported Storage Types</h4>
-<a href="https://cloud.google.com/storage">
-  <img alt="google cloud" src="https://img.shields.io/badge/google_cloud_storage-grey.svg?logo=google-cloud"/>
-</a>
-
-<a href="https://cloud.google.com/storage">
-  <img alt="google cloud" src="https://img.shields.io/badge/aws_s3-grey?logo=amazons3"/>
-</a>
 

--- a/README.md
+++ b/README.md
@@ -91,14 +91,34 @@ Types of extras that can be installed:
   poetry add "opsml[server]"
   ```
 
-- **GCP-mysql**: Installs mysql and cloud-sql gcp dependencies to be used with `Opsml`
+- **GCP with mysql**: Installs mysql and gcsfs to be used with `Opsml`
+  ```bash
+  poetry add "opsml[gcs,mysql]"
+  ```
+
+- **GCP with mysql(cloud-sql)**: Installs mysql and cloud-sql gcp dependencies to be used with `Opsml`
   ```bash
   poetry add "opsml[gcp_mysql]"
   ```
 
-- **GCP-postgres**: Installs postgres and cloud-sql gcp dependencies to be used with `Opsml`
+- **GCP with postgres**: Installs postgres and gcsgs to be used with `Opsml`
+  ```bash
+  poetry add "opsml[gcs,postgres]"
+  ```
+
+- **GCP with postgres(cloud-sql)**: Installs postgres and cloud-sql gcp dependencies to be used with `Opsml`
   ```bash
   poetry add "opsml[gcp_postgres]"
+  ```
+
+- **AWS with postgres**: Installs postgres and s3fs dependencies to be used with `Opsml`
+  ```bash
+  poetry add "opsml[s3,postgres]"
+  ```
+
+- **AWS with mysql**: Installs postgres and s3fs dependencies to be used with `Opsml`
+  ```bash
+  poetry add "opsml[s3,mysql]"
   ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -45,8 +45,14 @@
   <img alt="lightgbm" src=https://img.shields.io/badge/Package-LightGBM-success"/>
 
 <h4 align="left">Supported Storage Types</h4>
-<a href="https://lightgbm.readthedocs.io/en/v3.3.2/">
-  <img alt="lightgbm" src=https://img.shields.io/badge/Package-LightGBM-success"/>
+<a href="https://cloud.google.com/storage">
+  <img alt="google cloud" src="https://img.shields.io/badge/google_cloud_storage-grey.svg?logo=google-cloud"/>
+</a>
+
+<a href="https://cloud.google.com/storage">
+  <img alt="google cloud" src="https://img.shields.io/badge/aws_s3-grey?logo=amazons3"/>
+</a>
+
 
 <p align="center">
   <a href="#what-is-it">What is it?</a> •

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 
 <h4 align="left">Supported Model Types</h4
 
-![Keras](https://img.shields.io/badge/Keras-FF0000?logo=keras&logoColor=white)
-![Pytorch](https://img.shields.io/badge/PyTorch--EE4C2C.svg?style=flat&logo=pytorch)
+[![Keras](https://img.shields.io/badge/Keras-FF0000?logo=keras&logoColor=white)]()
+[![Pytorch](https://img.shields.io/badge/PyTorch--EE4C2C.svg?style=flat&logo=pytorch)]()
 [![Sklearn](https://img.shields.io/badge/scikit_learn-F7931E?logo=scikit-learn&logoColor=white)](https://scikit-learn.org/stable/)
 [![Xgboost](https://img.shields.io/badge/Package-XGBoost-blueviolet)](https://xgboost.readthedocs.io/en/stable/)
 [![Lightgbm](https://img.shields.io/badge/Package-LightGBM-success)](https://lightgbm.readthedocs.io/en/v3.3.2/)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@
 <a href="https://lightgbm.readthedocs.io/en/v3.3.2/">
   <img alt="lightgbm" src=https://img.shields.io/badge/Package-LightGBM-success"/>
 
-</p>
+<h4 align="left">Supported Storage Types</h4>
+<a href="https://lightgbm.readthedocs.io/en/v3.3.2/">
+  <img alt="lightgbm" src=https://img.shields.io/badge/Package-LightGBM-success"/>
+
 <p align="center">
   <a href="#what-is-it">What is it?</a> •
   <a href="#features">Features</a> •

--- a/README.md
+++ b/README.md
@@ -8,50 +8,23 @@
 
 <h1 align="center"><a href="https://thorrester.github.io/opsml-ghpages/">OpsML Documentation</h1>
 
-<div align="center">
- <a alt="Tests" href="https://github.com/shipt/opsml/actions/workflows/lint-unit-tests.yml">
-      <img src="https://github.com/shipt/opsml/actions/workflows/lint-unit-tests.yml/badge.svg?branch=main">
- </a> 
- <a href=""><img alt="Code Style" src="https://img.shields.io/badge/  code%20style-black-000000.svg">
- </a>
- <a href="https://pypi.org/project/opsml" target="_blank">
-    <img src="https://img.shields.io/pypi/pyversions/opsml.svg?color=%2334D058" alt="Supported Python versions">
-  </a>
-
-</div>
- 
-<div align="center">
-  <a href="https://keras.io/">
-    <img alt="keras"" src="https://img.shields.io/badge/Keras-FF0000?logo=keras&logoColor=white"/>
-
-  <a href="https://pytorch.org/">
-    <img alt="pytorch" src="https://img.shields.io/badge/PyTorch--EE4C2C.svg?style=flat&logo=pytorch"/>
-
-  <a href="https://scikit-learn.org/stable/">
-    <img alt="scikit-learn" src="https://img.shields.io/badge/scikit_learn-F7931E?logo=scikit-learn&logoColor=white"/>
+[![Tests](https://github.com/shipt/opsml/actions/workflows/lint-unit-tests.yml/badge.svg?branch=main)](https://github.com/shipt/opsml/actions/workflows/lint-unit-tests.yml)
+![Style](https://img.shields.io/badge/code%20style-black-000000.svg)
+[![Py-Versions](https://img.shields.io/pypi/pyversions/opsml.svg?color=%2334D058)](https://pypi.org/project/opsml)
 
 
-  <a href="https://xgboost.readthedocs.io/en/stable/">
-    <img alt="xgboost" src=https://img.shields.io/badge/Package-XGBoost-blueviolet"/>
+<h4 align="left">Supported Model Types</h4
 
-
-  <a href="https://lightgbm.readthedocs.io/en/v3.3.2/">
-    <img alt="lightgbm" src=https://img.shields.io/badge/Package-LightGBM-success"/>
-</div>
+![Keras](https://img.shields.io/badge/Keras-FF0000?logo=keras&logoColor=white)
+![Pytorch](https://img.shields.io/badge/PyTorch--EE4C2C.svg?style=flat&logo=pytorch)
+[![Sklearn](https://img.shields.io/badge/scikit_learn-F7931E?logo=scikit-learn&logoColor=white)](https://scikit-learn.org/stable/)
+[![Xgboost](https://img.shields.io/badge/Package-XGBoost-blueviolet)](https://xgboost.readthedocs.io/en/stable/)
+[![Lightgbm](https://img.shields.io/badge/Package-LightGBM-success)](https://lightgbm.readthedocs.io/en/v3.3.2/)
 
 <h4 align="left">Supported Storage Types</h4>
 
-<div align="center">
-  <a href="https://cloud.google.com/storage">
-    <img alt="google cloud" src="https://img.shields.io/badge/google_cloud_storage-grey.svg?logo=google-cloud"/>
-  </a>
-
-  <a href="https://cloud.google.com/storage">
-    <img alt="google cloud" src="https://img.shields.io/badge/aws_s3-grey?logo=amazons3"/>
-  </a>
-</div>
-
-
+[![GCS](https://img.shields.io/badge/google_cloud_storage-grey.svg?logo=google-cloud)](https://cloud.google.com/storage)
+[![S3](https://img.shields.io/badge/aws_s3-grey?logo=amazons3)](https://aws.amazon.com/)
 
 <p align="center">
   <a href="#what-is-it">What is it?</a> •

--- a/README.md
+++ b/README.md
@@ -8,18 +8,18 @@
 
 <h1 align="center"><a href="https://thorrester.github.io/opsml-ghpages/">OpsML Documentation</h1>
 
-
-
-   <a alt="Tests" href="https://github.com/shipt/opsml/actions/workflows/lint-unit-tests.yml">
+<div align="center">
+ <a alt="Tests" href="https://github.com/shipt/opsml/actions/workflows/lint-unit-tests.yml">
       <img src="https://github.com/shipt/opsml/actions/workflows/lint-unit-tests.yml/badge.svg?branch=main">
-  </a>
-  <img alt="Code Style" src="https://img.shields.io/badge/  code%20style-black-000000.svg" />
-  <a href="https://www.python.org/downloads/release/python-390/">
-  </a>
-  <a href="https://pypi.org/project/opsml" target="_blank">
+ </a> 
+ <a href=""><img alt="Code Style" src="https://img.shields.io/badge/  code%20style-black-000000.svg">
+ </a>
+ <a href="https://pypi.org/project/opsml" target="_blank">
     <img src="https://img.shields.io/pypi/pyversions/opsml.svg?color=%2334D058" alt="Supported Python versions">
   </a>
 
+</div>
+ 
 
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <h1 align="center"><a href="https://thorrester.github.io/opsml-ghpages/">OpsML Documentation</h1>
 
-<p align="center">
+
 
    <a alt="Tests" href="https://github.com/shipt/opsml/actions/workflows/lint-unit-tests.yml">
       <img src="https://github.com/shipt/opsml/actions/workflows/lint-unit-tests.yml/badge.svg?branch=main">
@@ -20,38 +20,7 @@
     <img src="https://img.shields.io/pypi/pyversions/opsml.svg?color=%2334D058" alt="Supported Python versions">
   </a>
 
-</p>
 
-<h4 align="left">Supported Model Types</h4>
-
-<a href="https://www.tensorflow.org/">
-  <img alt="tensorflow" src="https://img.shields.io/badge/TensorFlow-FF6F00?logo=tensorflow&logoColor=white"/>
-
-<a href="https://keras.io/">
-  <img alt="keras"" src="https://img.shields.io/badge/Keras-FF0000?logo=keras&logoColor=white"/>
-
-<a href="https://pytorch.org/">
-  <img alt="pytorch" src="https://img.shields.io/badge/PyTorch--EE4C2C.svg?style=flat&logo=pytorch"/>
-
-<a href="https://scikit-learn.org/stable/">
-  <img alt="scikit-learn" src="https://img.shields.io/badge/scikit_learn-F7931E?logo=scikit-learn&logoColor=white"/>
-
-
-<a href="https://xgboost.readthedocs.io/en/stable/">
-  <img alt="xgboost" src=https://img.shields.io/badge/Package-XGBoost-blueviolet"/>
-
-
-<a href="https://lightgbm.readthedocs.io/en/v3.3.2/">
-  <img alt="lightgbm" src=https://img.shields.io/badge/Package-LightGBM-success"/>
-
-<h4 align="left">Supported Storage Types</h4>
-<a href="https://cloud.google.com/storage">
-  <img alt="google cloud" src="https://img.shields.io/badge/google_cloud_storage-grey.svg?logo=google-cloud"/>
-</a>
-
-<a href="https://cloud.google.com/storage">
-  <img alt="google cloud" src="https://img.shields.io/badge/aws_s3-grey?logo=amazons3"/>
-</a>
 
 
 <p align="center">
@@ -137,3 +106,32 @@ Thanks goes to these phenomenal [projects and people](./ATTRIBUTIONS.md) and peo
 <a href="https://github.com/shipt/opsml/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=shipt/opsml" />
 </a>
+
+
+
+<a href="https://keras.io/">
+  <img alt="keras"" src="https://img.shields.io/badge/Keras-FF0000?logo=keras&logoColor=white"/>
+
+<a href="https://pytorch.org/">
+  <img alt="pytorch" src="https://img.shields.io/badge/PyTorch--EE4C2C.svg?style=flat&logo=pytorch"/>
+
+<a href="https://scikit-learn.org/stable/">
+  <img alt="scikit-learn" src="https://img.shields.io/badge/scikit_learn-F7931E?logo=scikit-learn&logoColor=white"/>
+
+
+<a href="https://xgboost.readthedocs.io/en/stable/">
+  <img alt="xgboost" src=https://img.shields.io/badge/Package-XGBoost-blueviolet"/>
+
+
+<a href="https://lightgbm.readthedocs.io/en/v3.3.2/">
+  <img alt="lightgbm" src=https://img.shields.io/badge/Package-LightGBM-success"/>
+
+<h4 align="left">Supported Storage Types</h4>
+<a href="https://cloud.google.com/storage">
+  <img alt="google cloud" src="https://img.shields.io/badge/google_cloud_storage-grey.svg?logo=google-cloud"/>
+</a>
+
+<a href="https://cloud.google.com/storage">
+  <img alt="google cloud" src="https://img.shields.io/badge/aws_s3-grey?logo=amazons3"/>
+</a>
+

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -4,50 +4,24 @@
 
 <h4 align="center">Tooling for machine learning workflows</h4>
 ---
-<p align="center">
 
-   <a alt="Tests" href="https://github.com/shipt/opsml/actions/workflows/lint-unit-tests.yml">
-      <img src="https://github.com/shipt/opsml/actions/workflows/lint-unit-tests.yml/badge.svg?branch=main">
-  </a>
-  <img alt="Code Style" src="https://img.shields.io/badge/  code%20style-black-000000.svg" />
-  <a href="https://www.python.org/downloads/release/python-390/">
-  </a>
-  <a href="https://pypi.org/project/opsml" target="_blank">
-    <img src="https://img.shields.io/pypi/pyversions/opsml.svg?color=%2334D058" alt="Supported Python versions">
-  </a>
+[![Tests](https://github.com/shipt/opsml/actions/workflows/lint-unit-tests.yml/badge.svg?branch=main)](https://github.com/shipt/opsml/actions/workflows/lint-unit-tests.yml)
+![Style](https://img.shields.io/badge/code%20style-black-000000.svg)
+[![Py-Versions](https://img.shields.io/pypi/pyversions/opsml.svg?color=%2334D058)](https://pypi.org/project/opsml)
 
-</p>
 
-<h4 align="left">Supported Model Types</h4>
+<h4 align="left">Supported Model Types</h4
 
-<p align="center">
+![Keras](https://img.shields.io/badge/Keras-FF0000?logo=keras&logoColor=white)
+![Pytorch](https://img.shields.io/badge/PyTorch--EE4C2C.svg?style=flat&logo=pytorch)
+[![Sklearn](https://img.shields.io/badge/scikit_learn-F7931E?logo=scikit-learn&logoColor=white)](https://scikit-learn.org/stable/)
+[![Xgboost](https://img.shields.io/badge/Package-XGBoost-blueviolet)](https://xgboost.readthedocs.io/en/stable/)
+[![Lightgbm](https://img.shields.io/badge/Package-LightGBM-success)](https://lightgbm.readthedocs.io/en/v3.3.2/)
 
-<a href="https://www.tensorflow.org/">
-  <img alt="tensorflow" src="https://img.shields.io/badge/TensorFlow-FF6F00?logo=tensorflow&logoColor=white"/>
-</a>
+<h4 align="left">Supported Storage Types</h4>
 
-<a href="https://keras.io/">
-  <img alt="keras"" src="https://img.shields.io/badge/Keras-FF0000?logo=keras&logoColor=white"/>
-</a>
-
-<a href="https://pytorch.org/">
-  <img alt="pytorch" src="https://img.shields.io/badge/PyTorch--EE4C2C.svg?style=flat&logo=pytorch"/>
-</a>
-
-<a href="https://scikit-learn.org/stable/">
-  <img alt="scikit-learn" src="https://img.shields.io/badge/scikit_learn-F7931E?logo=scikit-learn&logoColor=white"/>
-</a>
-
-<a href="https://xgboost.readthedocs.io/en/stable/">
-  <img alt="xgboost" src=https://img.shields.io/badge/Package-XGBoost-blueviolet"/>
-</a>
-
-<a href="https://lightgbm.readthedocs.io/en/v3.3.2/">
-  <img alt="lightgbm" src=https://img.shields.io/badge/Package-LightGBM-success">
-</a>
-
-</p>
-
+[![GCS](https://img.shields.io/badge/google_cloud_storage-grey.svg?logo=google-cloud)](https://cloud.google.com/storage)
+[![S3](https://img.shields.io/badge/aws_s3-grey?logo=amazons3)](https://aws.amazon.com/)
 
 **Source Code**: [Code](https://github.com/shipt/opsml)
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -29,20 +29,40 @@ Types of extras that can be installed:
   poetry add "opsml[server]"
   ```
 
-- **GCP-mysql**: Installs mysql and cloud-sql gcp dependencies to be used with `Opsml`
+- **GCP with mysql**: Installs mysql and gcsfs to be used with `Opsml`
+  ```bash
+  poetry add "opsml[gcs,mysql]"
+  ```
+
+- **GCP with mysql(cloud-sql)**: Installs mysql and cloud-sql gcp dependencies to be used with `Opsml`
   ```bash
   poetry add "opsml[gcp_mysql]"
   ```
 
-- **GCP-postgres**: Installs postgres and cloud-sql gcp dependencies to be used with `Opsml`
+- **GCP with postgres**: Installs postgres and gcsgs to be used with `Opsml`
+  ```bash
+  poetry add "opsml[gcs,postgres]"
+  ```
+
+- **GCP with postgres(cloud-sql)**: Installs postgres and cloud-sql gcp dependencies to be used with `Opsml`
   ```bash
   poetry add "opsml[gcp_postgres]"
   ```
 
-### Example setup for gcp-backed postgres with opsml mlflow server
+- **AWS with postgres**: Installs postgres and s3fs dependencies to be used with `Opsml`
+  ```bash
+  poetry add "opsml[s3,postgres]"
+  ```
+
+- **AWS with mysql**: Installs postgres and s3fs dependencies to be used with `Opsml`
+  ```bash
+  poetry add "opsml[s3,mysql]"
+  ```
+
+### Example setup for gcs storage and postgres with opsml mlflow server
 
 ```bash
-  poetry add "opsml[gcp_postgres, server]"
+  poetry add "opsml[gcs, postgres, server]"
 ```
 
 ## Environment Variables

--- a/opsml/model/creator.py
+++ b/opsml/model/creator.py
@@ -278,7 +278,7 @@ class OnnxModelCreator(ModelCreator):
                 additional_model_args=self.additional_model_args,
                 onnx_model_def=self.onnx_model_def,
             )
-
+            print(model_info)
             onnx_model_return = OnnxModelConverter(model_info=model_info).convert_model()
             onnx_model_return.model_type = self.model_type
             onnx_model_return.api_data_schema.model_data_schema.data_type = self.onnx_data_type

--- a/opsml/model/creator.py
+++ b/opsml/model/creator.py
@@ -74,7 +74,6 @@ class ModelCreator:
                 if model_type.validate(model_class_name=self.model_class)
             )
         )
-
         return model_type.get_type()
 
     def create_model(self) -> ModelReturn:
@@ -278,7 +277,7 @@ class OnnxModelCreator(ModelCreator):
                 additional_model_args=self.additional_model_args,
                 onnx_model_def=self.onnx_model_def,
             )
-            print(model_info)
+
             onnx_model_return = OnnxModelConverter(model_info=model_info).convert_model()
             onnx_model_return.model_type = self.model_type
             onnx_model_return.api_data_schema.model_data_schema.data_type = self.onnx_data_type

--- a/opsml/model/model_converters.py
+++ b/opsml/model/model_converters.py
@@ -363,6 +363,7 @@ class SklearnOnnxModel(ModelConverter):
     def update_sklearn_onnx_registries(self) -> bool:
         if self._is_pipeline:
             return self._update_onnx_registries_pipelines()
+
         if self._is_stacking_estimator:
             return self._update_onnx_registries_stacking()
 

--- a/opsml/model/model_converters.py
+++ b/opsml/model/model_converters.py
@@ -632,5 +632,5 @@ class OnnxModelConverter:
                 if converter.validate(model_type=self.model_info.model_type)
             )
         )
-
+        a
         return converter(model_info=self.model_info).convert()

--- a/opsml/model/model_types.py
+++ b/opsml/model/model_types.py
@@ -43,7 +43,18 @@ class SklearnEstimator(ModelType):
             "keras",
             "pytorch",
             "transformer",
+            "CalibratedClassifierCV",
         ]
+
+
+class SklearnCalibratedClassifier(ModelType):
+    @staticmethod
+    def get_type() -> str:
+        return OnnxModelType.CALIBRATED_CLASSIFIER.value
+
+    @staticmethod
+    def validate(model_class_name: str) -> bool:
+        return model_class_name == "CalibratedClassifierCV"
 
 
 class SklearnStackingEstimator(ModelType):

--- a/opsml/model/types.py
+++ b/opsml/model/types.py
@@ -31,6 +31,7 @@ class OnnxModelType(str, Enum):
     SKLEARN_PIPELINE = "sklearn_pipeline"
     SKLEARN_ESTIMATOR = "sklearn_estimator"
     STACKING_ESTIMATOR = "stackingestimator"
+    CALIBRATED_CLASSIFIER = "calibratedclassifier"
     LGBM_REGRESSOR = "lgbmregressor"
     LGBM_CLASSIFIER = "lgbmclassifier"
     XGB_REGRESSOR = "xgbregressor"

--- a/opsml/model/types.py
+++ b/opsml/model/types.py
@@ -31,7 +31,7 @@ class OnnxModelType(str, Enum):
     SKLEARN_PIPELINE = "sklearn_pipeline"
     SKLEARN_ESTIMATOR = "sklearn_estimator"
     STACKING_ESTIMATOR = "stackingestimator"
-    CALIBRATED_CLASSIFIER = "calibratedclassifier"
+    CALIBRATED_CLASSIFIER = "calibratedclassifiercv"
     LGBM_REGRESSOR = "lgbmregressor"
     LGBM_CLASSIFIER = "lgbmclassifier"
     XGB_REGRESSOR = "xgbregressor"
@@ -47,6 +47,7 @@ SKLEARN_SUPPORTED_MODEL_TYPES = [
     OnnxModelType.LGBM_REGRESSOR,
     OnnxModelType.LGBM_CLASSIFIER,
     OnnxModelType.XGB_REGRESSOR,
+    OnnxModelType.CALIBRATED_CLASSIFIER,
 ]
 
 LIGHTGBM_SUPPORTED_MODEL_TYPES = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -1998,13 +1998,13 @@ files = [
 
 [[package]]
 name = "jax"
-version = "0.4.18"
+version = "0.4.19"
 description = "Differentiate, compile, and transform Numpy code."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "jax-0.4.18-py3-none-any.whl", hash = "sha256:2ded3f558b74593c3533036a90c20d41ea35f35c74b25ca0fc86f4aafc388746"},
-    {file = "jax-0.4.18.tar.gz", hash = "sha256:776cf33890100803e98f45f9af10aa727271c6993d4e766c069118733c928132"},
+    {file = "jax-0.4.19-py3-none-any.whl", hash = "sha256:168462f53774d727eede0e3bfbc90b9946c708483564d3179b8e44bb54846b46"},
+    {file = "jax-0.4.19.tar.gz", hash = "sha256:29f87f9a50964d3ca5eeb2973de3462f0e8b4eca6d46027894a0e9a903420601"},
 ]
 
 [package.dependencies]
@@ -2015,20 +2015,20 @@ numpy = [
     {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
 ]
 opt-einsum = "*"
-scipy = ">=1.7"
+scipy = ">=1.9"
 
 [package.extras]
 australis = ["protobuf (>=3.13,<4)"]
-ci = ["jaxlib (==0.4.17)"]
-cpu = ["jaxlib (==0.4.18)"]
-cuda = ["jaxlib (==0.4.18+cuda11.cudnn86)"]
-cuda11-cudnn86 = ["jaxlib (==0.4.18+cuda11.cudnn86)"]
-cuda11-local = ["jaxlib (==0.4.18+cuda11.cudnn86)"]
-cuda11-pip = ["jaxlib (==0.4.18+cuda11.cudnn86)", "nvidia-cublas-cu11 (>=11.11)", "nvidia-cuda-cupti-cu11 (>=11.8)", "nvidia-cuda-nvcc-cu11 (>=11.8)", "nvidia-cuda-runtime-cu11 (>=11.8)", "nvidia-cudnn-cu11 (>=8.8)", "nvidia-cufft-cu11 (>=10.9)", "nvidia-cusolver-cu11 (>=11.4)", "nvidia-cusparse-cu11 (>=11.7)", "nvidia-nccl-cu11 (>=2.18.3)"]
-cuda12-local = ["jaxlib (==0.4.18+cuda12.cudnn89)"]
-cuda12-pip = ["jaxlib (==0.4.18+cuda12.cudnn89)", "nvidia-cublas-cu12 (>=12.2.5.6)", "nvidia-cuda-cupti-cu12 (>=12.2.142)", "nvidia-cuda-nvcc-cu12 (>=12.2.140)", "nvidia-cuda-runtime-cu12 (>=12.2.140)", "nvidia-cudnn-cu12 (>=8.9)", "nvidia-cufft-cu12 (>=11.0.8.103)", "nvidia-cusolver-cu12 (>=11.5.2)", "nvidia-cusparse-cu12 (>=12.1.2.141)", "nvidia-nccl-cu12 (>=2.18.3)"]
+ci = ["jaxlib (==0.4.18)"]
+cpu = ["jaxlib (==0.4.19)"]
+cuda = ["jaxlib (==0.4.19+cuda11.cudnn86)"]
+cuda11-cudnn86 = ["jaxlib (==0.4.19+cuda11.cudnn86)"]
+cuda11-local = ["jaxlib (==0.4.19+cuda11.cudnn86)"]
+cuda11-pip = ["jaxlib (==0.4.19+cuda11.cudnn86)", "nvidia-cublas-cu11 (>=11.11)", "nvidia-cuda-cupti-cu11 (>=11.8)", "nvidia-cuda-nvcc-cu11 (>=11.8)", "nvidia-cuda-runtime-cu11 (>=11.8)", "nvidia-cudnn-cu11 (>=8.8)", "nvidia-cufft-cu11 (>=10.9)", "nvidia-cusolver-cu11 (>=11.4)", "nvidia-cusparse-cu11 (>=11.7)", "nvidia-nccl-cu11 (>=2.18.3)"]
+cuda12-local = ["jaxlib (==0.4.19+cuda12.cudnn89)"]
+cuda12-pip = ["jaxlib (==0.4.19+cuda12.cudnn89)", "nvidia-cublas-cu12 (>=12.2.5.6)", "nvidia-cuda-cupti-cu12 (>=12.2.142)", "nvidia-cuda-nvcc-cu12 (>=12.2.140)", "nvidia-cuda-runtime-cu12 (>=12.2.140)", "nvidia-cudnn-cu12 (>=8.9)", "nvidia-cufft-cu12 (>=11.0.8.103)", "nvidia-cusolver-cu12 (>=11.5.2)", "nvidia-cusparse-cu12 (>=12.1.2.141)", "nvidia-nccl-cu12 (>=2.18.3)", "nvidia-nvjitlink-cu12 (>=12.2)"]
 minimum-jaxlib = ["jaxlib (==0.4.14)"]
-tpu = ["jaxlib (==0.4.18)", "libtpu-nightly (==0.1.dev20231006)", "requests"]
+tpu = ["jaxlib (==0.4.19)", "libtpu-nightly (==0.1.dev20231018)", "requests"]
 
 [[package]]
 name = "jinja2"
@@ -3985,13 +3985,13 @@ pylint-plugin-utils = "*"
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.3"
+version = "10.3.1"
 description = "Extension pack for Python Markdown."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pymdown_extensions-10.3-py3-none-any.whl", hash = "sha256:77a82c621c58a83efc49a389159181d570e370fff9f810d3a4766a75fc678b66"},
-    {file = "pymdown_extensions-10.3.tar.gz", hash = "sha256:94a0d8a03246712b64698af223848fd80aaf1ae4c4be29c8c61939b0467b5722"},
+    {file = "pymdown_extensions-10.3.1-py3-none-any.whl", hash = "sha256:8cba67beb2a1318cdaf742d09dff7c0fc4cafcc290147ade0f8fb7b71522711a"},
+    {file = "pymdown_extensions-10.3.1.tar.gz", hash = "sha256:f6c79941498a458852853872e379e7bab63888361ba20992fc8b4f8a9b61735e"},
 ]
 
 [package.dependencies]
@@ -6441,6 +6441,8 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [extras]
 gcp-mysql = ["cloud-sql-python-connector", "gcsfs", "pymysql"]
 gcp-postgres = ["cloud-sql-python-connector", "gcsfs", "pg8000"]
+gcs = ["gcsfs"]
+mysql = ["pymysql"]
 postgres = ["psycopg2"]
 s3 = ["boto3", "s3fs"]
 server = ["fastapi", "gunicorn", "prometheus-fastapi-instrumentator", "rollbar", "streaming-form-data", "uvicorn", "wsgi-basic-auth"]
@@ -6448,4 +6450,4 @@ server = ["fastapi", "gunicorn", "prometheus-fastapi-instrumentator", "rollbar",
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "72c286a75fbee415b2f4a4867fc9d221d7ca5147d66f8289893c6ddbc7fbfaef"
+content-hash = "0a702962e5982cb7602c9dd4dabb504dabcaf42adce75106b07d2b8ca2037448"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,9 @@ server = ["streaming-form-data", "fastapi", "uvicorn", "rollbar", "gunicorn", "p
 gcp_mysql = ["cloud-sql-python-connector", "pymysql", "gcsfs"]
 gcp_postgres = ["cloud-sql-python-connector", "pg8000", "gcsfs"]
 s3 = ["s3fs", "boto3"]
+gcs = ["gcsfs"]
 postgres = ["psycopg2"]
+mysql = ["pymysql"]
 
 [tool.poetry.group.dev]
 optional = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -924,13 +924,9 @@ def lgb_classifier_calibrated_pipeline(drift_dataframe):
         num_leaves=5,
     )
 
-    pipe = Pipeline(
-        [("preprocess", StandardScaler()), ("clf", CalibratedClassifierCV(reg, method="isotonic", cv=3))]
-    )
+    pipe = Pipeline([("preprocess", StandardScaler()), ("clf", CalibratedClassifierCV(reg, method="isotonic", cv=3))])
     pipe.fit(X_train, y_train)
 
-    print(pipe.__dict__)
-    a
     return pipe, X_test[:10]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -916,6 +916,25 @@ def lgb_classifier_calibrated(drift_dataframe):
 
 
 @pytest.fixture(scope="function")
+def lgb_classifier_calibrated_pipeline(drift_dataframe):
+    X_train, y_train, X_test, y_test = drift_dataframe
+    reg = lgb.LGBMClassifier(
+        n_estimators=3,
+        max_depth=3,
+        num_leaves=5,
+    )
+
+    pipe = Pipeline(
+        [("preprocess", StandardScaler()), ("clf", CalibratedClassifierCV(reg, method="isotonic", cv=3))]
+    )
+    pipe.fit(X_train, y_train)
+
+    print(pipe.__dict__)
+    a
+    return pipe, X_test[:10]
+
+
+@pytest.fixture(scope="function")
 def lgb_booster_dataframe(drift_dataframe):
     X_train, y_train, X_test, y_test = drift_dataframe
     # create dataset for lightgbm

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,7 @@ from sklearn.pipeline import Pipeline
 from sklearn.datasets import load_iris
 from sklearn.feature_selection import SelectPercentile, chi2
 from sklearn.preprocessing import OneHotEncoder, StandardScaler
+from sklearn.calibration import CalibratedClassifierCV
 from sklearn import ensemble
 from sklearn.model_selection import train_test_split
 from xgboost import XGBRegressor
@@ -896,6 +897,22 @@ def lgb_classifier(drift_dataframe):
     )
     reg.fit(X_train.to_numpy(), y_train)
     return reg, X_train[:100]
+
+
+@pytest.fixture(scope="function")
+def lgb_classifier_calibrated(drift_dataframe):
+    X_train, y_train, X_test, y_test = drift_dataframe
+    reg = lgb.LGBMClassifier(
+        n_estimators=3,
+        max_depth=3,
+        num_leaves=5,
+    )
+    reg.fit(X_train.to_numpy(), y_train)
+
+    calibrated_model = CalibratedClassifierCV(reg, method="isotonic", cv="prefit")
+    calibrated_model.fit(X_test, y_test)
+
+    return calibrated_model, X_test[:10]
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_model/test_onnx.py
+++ b/tests/test_model/test_onnx.py
@@ -56,85 +56,86 @@ def model_predict(model_and_data):
 @pytest.mark.parametrize(
     "model_and_data",
     [
-        lazy_fixture("linear_regression"),  # linear regress with numpy
-        lazy_fixture("random_forest_classifier"),  # random forest with dataframe
-        lazy_fixture("xgb_df_regressor"),  # xgb with dataframe
-        lazy_fixture("lgb_booster_dataframe"),  # lgb base package with dataframe
-        lazy_fixture("lgb_classifier"),  # lgb classifier with dataframe
-        lazy_fixture("sklearn_pipeline"),  # sklearn pipeline with dict onnx input
-        lazy_fixture("sklearn_pipeline_advanced"),
-        lazy_fixture("stacking_regressor"),  # stacking regressor with lgb as one estimator
-        ### test all supported sklearn estimators
-        lazy_fixture("ard_regression"),
-        lazy_fixture("ada_boost_classifier"),
-        lazy_fixture("ada_regression"),
-        lazy_fixture("bagging_classifier"),
-        lazy_fixture("bagging_regression"),
-        lazy_fixture("bayesian_ridge_regression"),
-        lazy_fixture("bernoulli_nb"),
-        lazy_fixture("categorical_nb"),
-        lazy_fixture("complement_nb"),
-        lazy_fixture("decision_tree_regressor"),
-        lazy_fixture("decision_tree_classifier"),
-        lazy_fixture("elastic_net"),
-        lazy_fixture("elastic_net_cv"),
-        lazy_fixture("extra_tree_regressor"),
-        lazy_fixture("extra_trees_regressor"),
-        lazy_fixture("extra_tree_classifier"),
-        lazy_fixture("extra_trees_classifier"),
-        lazy_fixture("gamma_regressor"),
-        lazy_fixture("gaussian_nb"),
-        lazy_fixture("gaussian_process_regressor"),
-        lazy_fixture("gradient_booster_classifier"),
-        lazy_fixture("gradient_booster_regressor"),
-        lazy_fixture("hist_booster_classifier"),
-        lazy_fixture("hist_booster_regressor"),
-        lazy_fixture("huber_regressor"),
-        lazy_fixture("knn_regressor"),
-        lazy_fixture("knn_classifier"),
-        lazy_fixture("lars_regressor"),
-        lazy_fixture("lars_cv_regressor"),
-        lazy_fixture("lasso_regressor"),
-        lazy_fixture("lasso_cv_regressor"),
-        lazy_fixture("lasso_lars_regressor"),
-        lazy_fixture("lasso_lars_cv_regressor"),
-        lazy_fixture("lasso_lars_ic_regressor"),
-        lazy_fixture("linear_svc"),
-        lazy_fixture("linear_svr"),
-        lazy_fixture("logistic_regression_cv"),
-        lazy_fixture("mlp_classifier"),
-        lazy_fixture("mlp_regressor"),
-        lazy_fixture("multioutput_classification"),
-        lazy_fixture("multioutput_regression"),
-        lazy_fixture("multitask_elasticnet"),
-        lazy_fixture("multitask_elasticnet_cv"),
-        lazy_fixture("multitask_lasso"),
-        lazy_fixture("multitask_lasso_cv"),
-        lazy_fixture("multinomial_nb"),
-        lazy_fixture("nu_svc"),
-        lazy_fixture("nu_svr"),
-        lazy_fixture("pls_regressor"),
-        lazy_fixture("passive_aggressive_classifier"),
-        lazy_fixture("passive_aggressive_regressor"),
-        lazy_fixture("perceptron"),
-        lazy_fixture("poisson_regressor"),
-        lazy_fixture("quantile_regressor"),
-        lazy_fixture("ransac_regressor"),
-        lazy_fixture("radius_neighbors_regressor"),
-        lazy_fixture("radius_neighbors_classifier"),
-        lazy_fixture("ridge_regressor"),
-        lazy_fixture("ridge_cv_regressor"),
-        lazy_fixture("ridge_classifier"),
-        lazy_fixture("ridge_cv_classifier"),
-        lazy_fixture("sgd_classifier"),
-        lazy_fixture("sgd_regressor"),
-        lazy_fixture("svc"),
-        lazy_fixture("svr"),
-        lazy_fixture("stacking_classifier"),
-        lazy_fixture("theilsen_regressor"),
-        lazy_fixture("tweedie_regressor"),
-        lazy_fixture("voting_classifier"),
-        lazy_fixture("voting_regressor"),
+        lazy_fixture("lgb_classifier_calibrated"),
+        # lazy_fixture("linear_regression"),  # linear regress with numpy
+        # lazy_fixture("random_forest_classifier"),  # random forest with dataframe
+        # lazy_fixture("xgb_df_regressor"),  # xgb with dataframe
+        # lazy_fixture("lgb_booster_dataframe"),  # lgb base package with dataframe
+        # lazy_fixture("lgb_classifier"),  # lgb classifier with dataframe
+        # lazy_fixture("sklearn_pipeline"),  # sklearn pipeline with dict onnx input
+        # lazy_fixture("sklearn_pipeline_advanced"),
+        # lazy_fixture("stacking_regressor"),  # stacking regressor with lgb as one estimator
+        #### test all supported sklearn estimators
+        # lazy_fixture("ard_regression"),
+        # lazy_fixture("ada_boost_classifier"),
+        # lazy_fixture("ada_regression"),
+        # lazy_fixture("bagging_classifier"),
+        # lazy_fixture("bagging_regression"),
+        # lazy_fixture("bayesian_ridge_regression"),
+        # lazy_fixture("bernoulli_nb"),
+        # lazy_fixture("categorical_nb"),
+        # lazy_fixture("complement_nb"),
+        # lazy_fixture("decision_tree_regressor"),
+        # lazy_fixture("decision_tree_classifier"),
+        # lazy_fixture("elastic_net"),
+        # lazy_fixture("elastic_net_cv"),
+        # lazy_fixture("extra_tree_regressor"),
+        # lazy_fixture("extra_trees_regressor"),
+        # lazy_fixture("extra_tree_classifier"),
+        # lazy_fixture("extra_trees_classifier"),
+        # lazy_fixture("gamma_regressor"),
+        # lazy_fixture("gaussian_nb"),
+        # lazy_fixture("gaussian_process_regressor"),
+        # lazy_fixture("gradient_booster_classifier"),
+        # lazy_fixture("gradient_booster_regressor"),
+        # lazy_fixture("hist_booster_classifier"),
+        # lazy_fixture("hist_booster_regressor"),
+        # lazy_fixture("huber_regressor"),
+        # lazy_fixture("knn_regressor"),
+        # lazy_fixture("knn_classifier"),
+        # lazy_fixture("lars_regressor"),
+        # lazy_fixture("lars_cv_regressor"),
+        # lazy_fixture("lasso_regressor"),
+        # lazy_fixture("lasso_cv_regressor"),
+        # lazy_fixture("lasso_lars_regressor"),
+        # lazy_fixture("lasso_lars_cv_regressor"),
+        # lazy_fixture("lasso_lars_ic_regressor"),
+        # lazy_fixture("linear_svc"),
+        # lazy_fixture("linear_svr"),
+        # lazy_fixture("logistic_regression_cv"),
+        # lazy_fixture("mlp_classifier"),
+        # lazy_fixture("mlp_regressor"),
+        # lazy_fixture("multioutput_classification"),
+        # lazy_fixture("multioutput_regression"),
+        # lazy_fixture("multitask_elasticnet"),
+        # lazy_fixture("multitask_elasticnet_cv"),
+        # lazy_fixture("multitask_lasso"),
+        # lazy_fixture("multitask_lasso_cv"),
+        # lazy_fixture("multinomial_nb"),
+        # lazy_fixture("nu_svc"),
+        # lazy_fixture("nu_svr"),
+        # lazy_fixture("pls_regressor"),
+        # lazy_fixture("passive_aggressive_classifier"),
+        # lazy_fixture("passive_aggressive_regressor"),
+        # lazy_fixture("perceptron"),
+        # lazy_fixture("poisson_regressor"),
+        # lazy_fixture("quantile_regressor"),
+        # lazy_fixture("ransac_regressor"),
+        # lazy_fixture("radius_neighbors_regressor"),
+        # lazy_fixture("radius_neighbors_classifier"),
+        # lazy_fixture("ridge_regressor"),
+        # lazy_fixture("ridge_cv_regressor"),
+        # lazy_fixture("ridge_classifier"),
+        # lazy_fixture("ridge_cv_classifier"),
+        # lazy_fixture("sgd_classifier"),
+        # lazy_fixture("sgd_regressor"),
+        # lazy_fixture("svc"),
+        # lazy_fixture("svr"),
+        # lazy_fixture("stacking_classifier"),
+        # lazy_fixture("theilsen_regressor"),
+        # lazy_fixture("tweedie_regressor"),
+        # lazy_fixture("voting_classifier"),
+        # lazy_fixture("voting_regressor"),
     ],
 )
 def test_sklearn_models(model_and_data):
@@ -151,7 +152,7 @@ def test_sklearn_models(model_and_data):
         lazy_fixture("deeplabv3_resnet50"),  # deeplabv3_resnet50 trained with numpy array
     ],
 )
-def test_model_pytorch_predict(model_and_data):
+def _test_model_pytorch_predict(model_and_data):
     model_predict(model_and_data)
 
 
@@ -165,7 +166,7 @@ def test_model_pytorch_predict(model_and_data):
         lazy_fixture("load_multi_input_keras_example"),  # keras multi input model
     ],
 )
-def test_tensorflow_predict(model_and_data):
+def _test_tensorflow_predict(model_and_data):
     model_predict(model_and_data)
 
 
@@ -175,7 +176,7 @@ def test_tensorflow_predict(model_and_data):
         lazy_fixture("linear_regression"),  # linear regress with numpy
     ],
 )
-def test_byo_onnx(model_and_data):
+def _test_byo_onnx(model_and_data):
     model, data = model_and_data
 
     if isinstance(data, dict):
@@ -234,7 +235,7 @@ def test_byo_onnx(model_and_data):
         lazy_fixture("pytorch_onnx_byo"),  # linear regress with numpy
     ],
 )
-def test_byo_pytorch_onnx(model_and_data):
+def _test_byo_pytorch_onnx(model_and_data):
     model_def, model, sample_data = model_and_data
 
     # create model def first

--- a/tests/test_model/test_onnx.py
+++ b/tests/test_model/test_onnx.py
@@ -56,87 +56,87 @@ def model_predict(model_and_data):
 @pytest.mark.parametrize(
     "model_and_data",
     [
-        # lazy_fixture("lgb_classifier_calibrated"),
+        lazy_fixture("lgb_classifier_calibrated"),
         lazy_fixture("lgb_classifier_calibrated_pipeline"),
-        # lazy_fixture("linear_regression"),  # linear regress with numpy
-        # lazy_fixture("random_forest_classifier"),  # random forest with dataframe
-        # lazy_fixture("xgb_df_regressor"),  # xgb with dataframe
-        # lazy_fixture("lgb_booster_dataframe"),  # lgb base package with dataframe
-        # lazy_fixture("lgb_classifier"),  # lgb classifier with dataframe
-        # lazy_fixture("sklearn_pipeline"),  # sklearn pipeline with dict onnx input
-        # lazy_fixture("sklearn_pipeline_advanced"),
-        # lazy_fixture("stacking_regressor"),  # stacking regressor with lgb as one estimator
+        lazy_fixture("linear_regression"),  # linear regress with numpy
+        lazy_fixture("random_forest_classifier"),  # random forest with dataframe
+        lazy_fixture("xgb_df_regressor"),  # xgb with dataframe
+        lazy_fixture("lgb_booster_dataframe"),  # lgb base package with dataframe
+        lazy_fixture("lgb_classifier"),  # lgb classifier with dataframe
+        lazy_fixture("sklearn_pipeline"),  # sklearn pipeline with dict onnx input
+        lazy_fixture("sklearn_pipeline_advanced"),
+        lazy_fixture("stacking_regressor"),  # stacking regressor with lgb as one estimator
         #### test all supported sklearn estimators
-        # lazy_fixture("ard_regression"),
-        # lazy_fixture("ada_boost_classifier"),
-        # lazy_fixture("ada_regression"),
-        # lazy_fixture("bagging_classifier"),
-        # lazy_fixture("bagging_regression"),
-        # lazy_fixture("bayesian_ridge_regression"),
-        # lazy_fixture("bernoulli_nb"),
-        # lazy_fixture("categorical_nb"),
-        # lazy_fixture("complement_nb"),
-        # lazy_fixture("decision_tree_regressor"),
-        # lazy_fixture("decision_tree_classifier"),
-        # lazy_fixture("elastic_net"),
-        # lazy_fixture("elastic_net_cv"),
-        # lazy_fixture("extra_tree_regressor"),
-        # lazy_fixture("extra_trees_regressor"),
-        # lazy_fixture("extra_tree_classifier"),
-        # lazy_fixture("extra_trees_classifier"),
-        # lazy_fixture("gamma_regressor"),
-        # lazy_fixture("gaussian_nb"),
-        # lazy_fixture("gaussian_process_regressor"),
-        # lazy_fixture("gradient_booster_classifier"),
-        # lazy_fixture("gradient_booster_regressor"),
-        # lazy_fixture("hist_booster_classifier"),
-        # lazy_fixture("hist_booster_regressor"),
-        # lazy_fixture("huber_regressor"),
-        # lazy_fixture("knn_regressor"),
-        # lazy_fixture("knn_classifier"),
-        # lazy_fixture("lars_regressor"),
-        # lazy_fixture("lars_cv_regressor"),
-        # lazy_fixture("lasso_regressor"),
-        # lazy_fixture("lasso_cv_regressor"),
-        # lazy_fixture("lasso_lars_regressor"),
-        # lazy_fixture("lasso_lars_cv_regressor"),
-        # lazy_fixture("lasso_lars_ic_regressor"),
-        # lazy_fixture("linear_svc"),
-        # lazy_fixture("linear_svr"),
-        # lazy_fixture("logistic_regression_cv"),
-        # lazy_fixture("mlp_classifier"),
-        # lazy_fixture("mlp_regressor"),
-        # lazy_fixture("multioutput_classification"),
-        # lazy_fixture("multioutput_regression"),
-        # lazy_fixture("multitask_elasticnet"),
-        # lazy_fixture("multitask_elasticnet_cv"),
-        # lazy_fixture("multitask_lasso"),
-        # lazy_fixture("multitask_lasso_cv"),
-        # lazy_fixture("multinomial_nb"),
-        # lazy_fixture("nu_svc"),
-        # lazy_fixture("nu_svr"),
-        # lazy_fixture("pls_regressor"),
-        # lazy_fixture("passive_aggressive_classifier"),
-        # lazy_fixture("passive_aggressive_regressor"),
-        # lazy_fixture("perceptron"),
-        # lazy_fixture("poisson_regressor"),
-        # lazy_fixture("quantile_regressor"),
-        # lazy_fixture("ransac_regressor"),
-        # lazy_fixture("radius_neighbors_regressor"),
-        # lazy_fixture("radius_neighbors_classifier"),
-        # lazy_fixture("ridge_regressor"),
-        # lazy_fixture("ridge_cv_regressor"),
-        # lazy_fixture("ridge_classifier"),
-        # lazy_fixture("ridge_cv_classifier"),
-        # lazy_fixture("sgd_classifier"),
-        # lazy_fixture("sgd_regressor"),
-        # lazy_fixture("svc"),
-        # lazy_fixture("svr"),
-        # lazy_fixture("stacking_classifier"),
-        # lazy_fixture("theilsen_regressor"),
-        # lazy_fixture("tweedie_regressor"),
-        # lazy_fixture("voting_classifier"),
-        # lazy_fixture("voting_regressor"),
+        lazy_fixture("ard_regression"),
+        lazy_fixture("ada_boost_classifier"),
+        lazy_fixture("ada_regression"),
+        lazy_fixture("bagging_classifier"),
+        lazy_fixture("bagging_regression"),
+        lazy_fixture("bayesian_ridge_regression"),
+        lazy_fixture("bernoulli_nb"),
+        lazy_fixture("categorical_nb"),
+        lazy_fixture("complement_nb"),
+        lazy_fixture("decision_tree_regressor"),
+        lazy_fixture("decision_tree_classifier"),
+        lazy_fixture("elastic_net"),
+        lazy_fixture("elastic_net_cv"),
+        lazy_fixture("extra_tree_regressor"),
+        lazy_fixture("extra_trees_regressor"),
+        lazy_fixture("extra_tree_classifier"),
+        lazy_fixture("extra_trees_classifier"),
+        lazy_fixture("gamma_regressor"),
+        lazy_fixture("gaussian_nb"),
+        lazy_fixture("gaussian_process_regressor"),
+        lazy_fixture("gradient_booster_classifier"),
+        lazy_fixture("gradient_booster_regressor"),
+        lazy_fixture("hist_booster_classifier"),
+        lazy_fixture("hist_booster_regressor"),
+        lazy_fixture("huber_regressor"),
+        lazy_fixture("knn_regressor"),
+        lazy_fixture("knn_classifier"),
+        lazy_fixture("lars_regressor"),
+        lazy_fixture("lars_cv_regressor"),
+        lazy_fixture("lasso_regressor"),
+        lazy_fixture("lasso_cv_regressor"),
+        lazy_fixture("lasso_lars_regressor"),
+        lazy_fixture("lasso_lars_cv_regressor"),
+        lazy_fixture("lasso_lars_ic_regressor"),
+        lazy_fixture("linear_svc"),
+        lazy_fixture("linear_svr"),
+        lazy_fixture("logistic_regression_cv"),
+        lazy_fixture("mlp_classifier"),
+        lazy_fixture("mlp_regressor"),
+        lazy_fixture("multioutput_classification"),
+        lazy_fixture("multioutput_regression"),
+        lazy_fixture("multitask_elasticnet"),
+        lazy_fixture("multitask_elasticnet_cv"),
+        lazy_fixture("multitask_lasso"),
+        lazy_fixture("multitask_lasso_cv"),
+        lazy_fixture("multinomial_nb"),
+        lazy_fixture("nu_svc"),
+        lazy_fixture("nu_svr"),
+        lazy_fixture("pls_regressor"),
+        lazy_fixture("passive_aggressive_classifier"),
+        lazy_fixture("passive_aggressive_regressor"),
+        lazy_fixture("perceptron"),
+        lazy_fixture("poisson_regressor"),
+        lazy_fixture("quantile_regressor"),
+        lazy_fixture("ransac_regressor"),
+        lazy_fixture("radius_neighbors_regressor"),
+        lazy_fixture("radius_neighbors_classifier"),
+        lazy_fixture("ridge_regressor"),
+        lazy_fixture("ridge_cv_regressor"),
+        lazy_fixture("ridge_classifier"),
+        lazy_fixture("ridge_cv_classifier"),
+        lazy_fixture("sgd_classifier"),
+        lazy_fixture("sgd_regressor"),
+        lazy_fixture("svc"),
+        lazy_fixture("svr"),
+        lazy_fixture("stacking_classifier"),
+        lazy_fixture("theilsen_regressor"),
+        lazy_fixture("tweedie_regressor"),
+        lazy_fixture("voting_classifier"),
+        lazy_fixture("voting_regressor"),
     ],
 )
 def test_sklearn_models(model_and_data):
@@ -153,7 +153,7 @@ def test_sklearn_models(model_and_data):
         lazy_fixture("deeplabv3_resnet50"),  # deeplabv3_resnet50 trained with numpy array
     ],
 )
-def _test_model_pytorch_predict(model_and_data):
+def test_model_pytorch_predict(model_and_data):
     model_predict(model_and_data)
 
 
@@ -167,7 +167,7 @@ def _test_model_pytorch_predict(model_and_data):
         lazy_fixture("load_multi_input_keras_example"),  # keras multi input model
     ],
 )
-def _test_tensorflow_predict(model_and_data):
+def test_tensorflow_predict(model_and_data):
     model_predict(model_and_data)
 
 
@@ -177,7 +177,7 @@ def _test_tensorflow_predict(model_and_data):
         lazy_fixture("linear_regression"),  # linear regress with numpy
     ],
 )
-def _test_byo_onnx(model_and_data):
+def test_byo_onnx(model_and_data):
     model, data = model_and_data
 
     if isinstance(data, dict):
@@ -236,7 +236,7 @@ def _test_byo_onnx(model_and_data):
         lazy_fixture("pytorch_onnx_byo"),  # linear regress with numpy
     ],
 )
-def _test_byo_pytorch_onnx(model_and_data):
+def test_byo_pytorch_onnx(model_and_data):
     model_def, model, sample_data = model_and_data
 
     # create model def first

--- a/tests/test_model/test_onnx.py
+++ b/tests/test_model/test_onnx.py
@@ -56,7 +56,8 @@ def model_predict(model_and_data):
 @pytest.mark.parametrize(
     "model_and_data",
     [
-        lazy_fixture("lgb_classifier_calibrated"),
+        # lazy_fixture("lgb_classifier_calibrated"),
+        lazy_fixture("lgb_classifier_calibrated_pipeline"),
         # lazy_fixture("linear_regression"),  # linear regress with numpy
         # lazy_fixture("random_forest_classifier"),  # random forest with dataframe
         # lazy_fixture("xgb_df_regressor"),  # xgb with dataframe


### PR DESCRIPTION
## Pull Request

### Short Summary
Adds onnx support for `CalibratedClassifierCV`

### Context
During onnx conversion `CalibratedClassifierCV` with estimator types of XGBoost for LighGBM will fail because `opsml` does not check the estimator type and update the sklearn onnx registries as it does with other special types (pipelines, stacking). This PR adds additional logic to check for `CalibratedClassifierCV` and its underlying estimator type.

### Is this a Breaking Change?
No

