### PR TITLE
Enhancement/info to env

### DIFF
--- a/opsml/cards/base.py
+++ b/opsml/cards/base.py
@@ -1,6 +1,7 @@
 # Copyright (c) Shipt, Inc.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+import os
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -57,6 +58,16 @@ class ArtifactCard(BaseModel):
                     val = clean_string(val)
 
             card_args[key] = val
+
+        # check env vars
+        if card_args["name"] is None:
+            card_args["name"] = os.environ.get("OPSML_NAME")
+
+        if card_args["repository"] is None:
+            card_args["repository"] = os.environ.get("OPSML_REPOSITORY")
+
+        if card_args["contact"] is None:
+            card_args["contact"] = os.environ.get("OPSML_CONTACT")
 
         # validate name and repository for pattern
         validate_name_repository_pattern(name=card_args["name"], repository=card_args["repository"])

--- a/opsml/cards/base.py
+++ b/opsml/cards/base.py
@@ -24,9 +24,9 @@ class ArtifactCard(BaseModel):
         validate_default=True,
     )
 
-    name: str = os.environ.get("OPSML_RUNTIME_NAME")
-    repository: str = os.environ.get("OPSML_RUNTIME_REPOSITORY")
-    contact: str = os.environ.get("OPSML_RUNTIME_CONTACT")
+    name: str
+    repository: str
+    contact: str
     version: Optional[str] = None
     uid: Optional[str] = None
     info: Optional[CardInfo] = None

--- a/opsml/cards/base.py
+++ b/opsml/cards/base.py
@@ -61,13 +61,13 @@ class ArtifactCard(BaseModel):
 
         # check env vars
         if card_args["name"] is None:
-            card_args["name"] = os.environ.get("OPSML_NAME")
+            card_args["name"] = os.environ.get("OPSML_RUNTIME_NAME")
 
         if card_args["repository"] is None:
-            card_args["repository"] = os.environ.get("OPSML_REPOSITORY")
+            card_args["repository"] = os.environ.get("OPSML_RUNTIME_REPOSITORY")
 
         if card_args["contact"] is None:
-            card_args["contact"] = os.environ.get("OPSML_CONTACT")
+            card_args["contact"] = os.environ.get("OPSML_RUNTIME_CONTACT")
 
         # validate name and repository for pattern
         validate_name_repository_pattern(name=card_args["name"], repository=card_args["repository"])

--- a/opsml/cards/base.py
+++ b/opsml/cards/base.py
@@ -24,9 +24,9 @@ class ArtifactCard(BaseModel):
         validate_default=True,
     )
 
-    name: str
-    repository: str
-    contact: str
+    name: str = os.environ.get("OPSML_RUNTIME_NAME")
+    repository: str = os.environ.get("OPSML_RUNTIME_REPOSITORY")
+    contact: str = os.environ.get("OPSML_RUNTIME_CONTACT")
     version: Optional[str] = None
     uid: Optional[str] = None
     info: Optional[CardInfo] = None
@@ -48,26 +48,22 @@ class ArtifactCard(BaseModel):
         card_info = card_args.get("info")
 
         for key in ["name", "repository", "contact", "version", "uid"]:
+            # check card args
             val = card_args.get(key)
 
+            # check card info
             if card_info is not None:
                 val = val or getattr(card_info, key)
+
+            # check runtime env vars
+            if val is None:
+                val = os.environ.get(f"OPSML_RUNTIME_{key.upper()}")
 
             if key in ["name", "repository"]:
                 if val is not None:
                     val = clean_string(val)
 
             card_args[key] = val
-
-        # check env vars
-        if card_args["name"] is None:
-            card_args["name"] = os.environ.get("OPSML_RUNTIME_NAME")
-
-        if card_args["repository"] is None:
-            card_args["repository"] = os.environ.get("OPSML_RUNTIME_REPOSITORY")
-
-        if card_args["contact"] is None:
-            card_args["contact"] = os.environ.get("OPSML_RUNTIME_CONTACT")
 
         # validate name and repository for pattern
         validate_name_repository_pattern(name=card_args["name"], repository=card_args["repository"])

--- a/opsml/types/card.py
+++ b/opsml/types/card.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import datetime
+import os
 from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List, Optional, Union
@@ -98,6 +99,17 @@ class CardInfo:
     uid: Optional[str] = None
     version: Optional[str] = None
     tags: Optional[Dict[str, str]] = None
+
+    def set_env(self) -> "CardInfo":
+        """Helper to set environment variables for the current runtime environment"""
+        if self.name is not None:
+            os.environ["OPSML_NAME"] = self.name
+        if self.repository is not None:
+            os.environ["OPSML_REPOSITORY"] = self.repository
+        if self.contact is not None:
+            os.environ["OPSML_CONTACT"] = self.contact
+
+        return self
 
 
 class CardType(str, Enum):

--- a/opsml/types/card.py
+++ b/opsml/types/card.py
@@ -103,11 +103,11 @@ class CardInfo:
     def set_env(self) -> "CardInfo":
         """Helper to set environment variables for the current runtime environment"""
         if self.name is not None:
-            os.environ["OPSML_NAME"] = self.name
+            os.environ["OPSML_RUNTIME_NAME"] = self.name
         if self.repository is not None:
-            os.environ["OPSML_REPOSITORY"] = self.repository
+            os.environ["OPSML_RUNTIME_REPOSITORY"] = self.repository
         if self.contact is not None:
-            os.environ["OPSML_CONTACT"] = self.contact
+            os.environ["OPSML_RUNTIME_CONTACT"] = self.contact
 
         return self
 

--- a/opsml/types/card.py
+++ b/opsml/types/card.py
@@ -102,12 +102,12 @@ class CardInfo:
 
     def set_env(self) -> "CardInfo":
         """Helper to set environment variables for the current runtime environment"""
-        if self.name is not None:
-            os.environ["OPSML_RUNTIME_NAME"] = self.name
-        if self.repository is not None:
-            os.environ["OPSML_RUNTIME_REPOSITORY"] = self.repository
-        if self.contact is not None:
-            os.environ["OPSML_RUNTIME_CONTACT"] = self.contact
+
+        for key in ["name", "repository", "contact"]:
+            value = getattr(self, key)
+
+            if value is not None:
+                os.environ[f"OPSML_RUNTIME_{key.upper()}"] = value
 
         return self
 

--- a/tests/test_projects/test_opsml_project.py
+++ b/tests/test_projects/test_opsml_project.py
@@ -227,23 +227,22 @@ def test_project_card_info_env_var(
     card_info = CardInfo(name="test-card", repository="opsml", contact="opsml_user").set_env()
     project_info = ProjectInfo(name="test-exp")
     model, data = sklearn_pipeline
-    
+
     with OpsmlProject(info=project_info).run() as run:
         run = cast(ActiveRun, run)
-        
+
         # data card should inherit card info from env vars
         datacard = DataCard(interface=data)
         run.register_card(card=datacard)
-        
+
         # model card should inherit card info from env vars
         modelcard = ModelCard(interface=model, datacard_uid=datacard.uid)
         run.register_card(card=modelcard)
-        
+
     assert datacard.name == card_info.name
     assert datacard.repository == card_info.repository
     assert datacard.contact == card_info.contact
-    
+
     assert modelcard.name == card_info.name
     assert modelcard.repository == card_info.repository
     assert modelcard.contact == card_info.contact
-    

--- a/tests/test_projects/test_opsml_project.py
+++ b/tests/test_projects/test_opsml_project.py
@@ -216,3 +216,34 @@ def test_opsml_project_list_runs(db_registries: CardRegistries) -> None:
         run.log_parameter(key="m1", value="apple")
 
     assert len(OpsmlProject(info=info).list_runs()) > 0
+
+
+def test_project_card_info_env_var(
+    db_registries: CardRegistries,
+    sklearn_pipeline: Tuple[SklearnModel, PandasData],
+) -> None:
+    """Verify that we can set card info via env vars"""
+
+    card_info = CardInfo(name="test-card", repository="opsml", contact="opsml_user").set_env()
+    project_info = ProjectInfo(name="test-exp")
+    model, data = sklearn_pipeline
+    
+    with OpsmlProject(info=project_info).run() as run:
+        run = cast(ActiveRun, run)
+        
+        # data card should inherit card info from env vars
+        datacard = DataCard(interface=data)
+        run.register_card(card=datacard)
+        
+        # model card should inherit card info from env vars
+        modelcard = ModelCard(interface=model, datacard_uid=datacard.uid)
+        run.register_card(card=modelcard)
+        
+    assert datacard.name == card_info.name
+    assert datacard.repository == card_info.repository
+    assert datacard.contact == card_info.contact
+    
+    assert modelcard.name == card_info.name
+    assert modelcard.repository == card_info.repository
+    assert modelcard.contact == card_info.contact
+    

--- a/tests/test_projects/test_types.py
+++ b/tests/test_projects/test_types.py
@@ -16,4 +16,3 @@ def test_project_id() -> None:
 
     with pytest.raises(pydantic.ValidationError):
         types.ProjectInfo(name="", repository="a", tracking_uri="test")
-


### PR DESCRIPTION
## Pull Request

### Short Summary
Allow users to set `runtime` envs from `cardinfo`

### Context
This PR adds the ability to set environment variables from `name`, `repository` and `contact` from `CardInfo`. Naming convention will follow `OPSML_RUNTIME_{ATTR}`


