### PR TITLE
Migrate cards overview to mermaidjs.

### DIFF
--- a/docs/docs/cards/overview.md
+++ b/docs/docs/cards/overview.md
@@ -1,24 +1,48 @@
 Cards (aka ArtifactCards) are one of the primary data structures for working with `Opsml` that contain both data and model interface objects as well as associated metadata. `ArtifactCards` are stored in registries and can be used to track and version data and models.
 
+<style>
+  .registry {
+    fill:#5e0fb7;
+    stroke:black;
+    stroke-width:2px;
+    color:white;
+    font-weight:bolder;
+  }
+</style>
 ```mermaid
+
+
 flowchart TD
   DS(["fa:fa-user-group" DS])
     DS --> Model([Model])
       Model --> Metrics([Metrics])
         Metrics --> RunCard(RunCard)
-          RunCard --> RunRegistry[(Run Registry)]
+          RunCard --> RunRegistry[(RunRegistry)]
       Model --> ModelCard
         subgraph ModelCard
           OnnxModel([OnnxModel])
           ModelCardDataCard(DataCard)
         end
-        ModelCard --> ModelRegistry[(Model Registry)]
+        ModelCard --> ModelRegistry[(ModelRegistry)]
         ModelCard --> DeployableArtifact(Deployable Artifact)
     DS --> Data([Data])
       Data --> DataCard(DataCard)
         DataCard --> ModelCardDataCard
-        DataCard --> DataRegistry[(Data Registry)]
+        DataCard --> DataRegistry[(DataRegistry)]
 
+  style DS fill:#028e6b,stroke:black,stroke-width:2px,color:white,font-weight:bolder
+  style Model fill:#028e6b,stroke:black,stroke-width:2px,color:white,font-weight:bolder
+  style Metrics fill:#028e6b,stroke:black,stroke-width:2px,color:white,font-weight:bolder
+  style Data fill:#028e6b,stroke:black,stroke-width:2px,color:white,font-weight:bolder
+  style RunCard fill:#028e6b,stroke:black,stroke-width:2px,color:white,font-weight:bolder
+  style OnnxModel fill:#028e6b,stroke:black,stroke-width:2px,color:white,font-weight:bolder
+  style DataCard fill:#028e6b,stroke:black,stroke-width:2px,color:white,font-weight:bolder
+  style ModelCardDataCard fill:#028e6b,stroke:black,stroke-width:2px,color:white,font-weight:bolder
+  style DeployableArtifact fill:#028e6b,stroke:black,stroke-width:2px,color:white,font-weight:bolder
+
+  style RunRegistry fill:#5e0fb7,stroke:black,stroke-width:2px,color:white,font-weight:bolder
+  style ModelRegistry fill:#5e0fb7,stroke:black,stroke-width:2px,color:white,font-weight:bolder
+  style DataRegistry fill:#5e0fb7,stroke:black,stroke-width:2px,color:white,font-weight:bolder
 ```
 
 

--- a/docs/docs/cards/overview.md
+++ b/docs/docs/cards/overview.md
@@ -1,8 +1,26 @@
 Cards (aka ArtifactCards) are one of the primary data structures for working with `Opsml` that contain both data and model interface objects as well as associated metadata. `ArtifactCards` are stored in registries and can be used to track and version data and models.
 
-<p align="center">
-  <img src="../../images/card-flow.png" width="457" height="332"/>
-</p>
+```mermaid
+flowchart TD
+  DS(["fa:fa-user-group" DS])
+    DS --> Model([Model])
+      Model --> Metrics([Metrics])
+        Metrics --> RunCard(RunCard)
+          RunCard --> RunRegistry[(Run Registry)]
+      Model --> ModelCard
+        subgraph ModelCard
+          OnnxModel([OnnxModel])
+          ModelCardDataCard(DataCard)
+        end
+        ModelCard --> ModelRegistry[(Model Registry)]
+        ModelCard --> DeployableArtifact(Deployable Artifact)
+    DS --> Data([Data])
+      Data --> DataCard(DataCard)
+        DataCard --> ModelCardDataCard
+        DataCard --> DataRegistry[(Data Registry)]
+
+```
+
 
 ## Card Types
 

--- a/docs/docs/cards/overview.md
+++ b/docs/docs/cards/overview.md
@@ -1,17 +1,6 @@
 Cards (aka ArtifactCards) are one of the primary data structures for working with `Opsml` that contain both data and model interface objects as well as associated metadata. `ArtifactCards` are stored in registries and can be used to track and version data and models.
 
-<style>
-  .registry {
-    fill:#5e0fb7;
-    stroke:black;
-    stroke-width:2px;
-    color:white;
-    font-weight:bolder;
-  }
-</style>
 ```mermaid
-
-
 flowchart TD
   DS(["fa:fa-user-group" DS])
     DS --> Model([Model])

--- a/docs/docs/interfaces/model/deployment.md
+++ b/docs/docs/interfaces/model/deployment.md
@@ -18,7 +18,7 @@ flowchart LR
     end
 
     subgraph CICD
-    modelreg --> dir(Direcotry)
+    modelreg --> dir(Directory)
     dir --> |package|docker(DockerFile)
     end
 
@@ -57,7 +57,7 @@ flowchart LR
     style vis fill:#028e6b,stroke:black,stroke-width:2px,color:white,font-weight:bolder
 
     style datareg fill:#5e0fb7,stroke:black,stroke-width:2px,color:white,font-weight:bolder
-    style modelreg fill:#5e0fb7,stroke:black,stroke-width:2px,color:white,font-weight:bolderack
+    style modelreg fill:#5e0fb7,stroke:black,stroke-width:2px,color:white,font-weight:bolder
 ```
 
 ## Steps:


### PR DESCRIPTION
## Pull Request

### Short Summary
This removes the existing png and incorporates a mermaid representation of the workflow of an artifact card. Here is a comparison of the two: https://github.com/chrishalbert/opsml/blob/244-cards-overview-to-mermaidjs/docs/docs/cards/overview.md vs https://thorrester.github.io/opsml-ghpages/cards/overview/ 

![image](https://github.com/shipt/opsml/assets/16158060/b5d14daf-7764-4269-8b01-f6e639747a3c)

It could use some work, and I'm also unclear on the `OnnxModel`. I'm interested in feedback!

### Context
This is in reference to the effort supporting issue #244 

### Is this a Breaking Change?
No!
