### PR TITLE
Project Id Solution

### DIFF
--- a/opsml/app/routes/projects.py
+++ b/opsml/app/routes/projects.py
@@ -76,7 +76,7 @@ def project_id(
     project_name: str,
     repository: str,
 ) -> ProjectIdResponse:
-    """Get all repositories associated with a registry
+    """Get the project ID for the given name / repository.
 
     Args:
         request:
@@ -87,7 +87,7 @@ def project_id(
             Name of the repository
 
     Returns:
-        `RepositoriesResponse`
+        `ProjetIdResponse`
     """
 
     registry: ServerProjectCardRegistry = request.app.state.registries.project._registry
@@ -102,14 +102,14 @@ def project_id(
 
 @router.get("/projects/max_id", response_model=ProjectIdResponse, name="project_id")
 def max_project_id(request: Request) -> ProjectIdResponse:
-    """Get all repositories associated with a registry
+    """Get the current maximum project id (used for creating new projects)
 
     Args:
         request:
             FastAPI request object
 
     Returns:
-        `RepositoriesResponse`
+        `ProjectIdResponse`
     """
     registry: ServerProjectCardRegistry = request.app.state.registries.project._registry
     return ProjectIdResponse(project_id=registry.get_max_project_id())

--- a/opsml/app/routes/projects.py
+++ b/opsml/app/routes/projects.py
@@ -87,7 +87,7 @@ def project_id(
             Name of the repository
 
     Returns:
-        `ProjetIdResponse`
+        `ProjectIdResponse`
     """
 
     registry: ServerProjectCardRegistry = request.app.state.registries.project._registry
@@ -98,18 +98,3 @@ def project_id(
             repository=repository,
         )
     )
-
-
-@router.get("/projects/max_id", response_model=ProjectIdResponse, name="project_id")
-def max_project_id(request: Request) -> ProjectIdResponse:
-    """Get the current maximum project id (used for creating new projects)
-
-    Args:
-        request:
-            FastAPI request object
-
-    Returns:
-        `ProjectIdResponse`
-    """
-    registry: ServerProjectCardRegistry = request.app.state.registries.project._registry
-    return ProjectIdResponse(project_id=registry.get_max_project_id())

--- a/opsml/app/routes/pydantic_models.py
+++ b/opsml/app/routes/pydantic_models.py
@@ -367,4 +367,4 @@ class AuditReport(BaseModel):
 
 
 class ProjectIdResponse(BaseModel):
-    project_id: Optional[int] = None
+    project_id: int

--- a/opsml/app/routes/pydantic_models.py
+++ b/opsml/app/routes/pydantic_models.py
@@ -364,3 +364,7 @@ class AuditReport(BaseModel):
     audit: Optional[Dict[str, Any]] = AuditSections().model_dump()  # type: ignore
     timestamp: Optional[str] = None
     comments: List[Optional[Comment]] = []
+
+
+class ProjectIdResponse(BaseModel):
+    project_id: Optional[int] = None

--- a/opsml/cards/project.py
+++ b/opsml/cards/project.py
@@ -17,7 +17,7 @@ class ProjectCard(ArtifactCard):
     Card containing project information
     """
 
-    project_id: int
+    project_id: int = 0  # placeholder
 
     def create_registry_record(self) -> Dict[str, Any]:
         """Creates a registry record for a project"""

--- a/opsml/projects/active_run.py
+++ b/opsml/projects/active_run.py
@@ -49,7 +49,7 @@ class CardHandler:
     def register_card(
         registries: CardRegistries,
         card: ArtifactCard,
-        version_type: VersionType = VersionType.MINOR,
+        version_type: Union[VersionType, str] = VersionType.MINOR,
     ) -> None:
         """Registers and ArtifactCard"""
 
@@ -125,7 +125,11 @@ class ActiveRun:
         for key, value in tags.items():
             self.add_tag(key=key, value=cast(str, value))
 
-    def register_card(self, card: ArtifactCard, version_type: VersionType = VersionType.MINOR) -> None:
+    def register_card(
+        self,
+        card: ArtifactCard,
+        version_type: Union[VersionType, str] = VersionType.MINOR,
+    ) -> None:
         """
         Register a given artifact card.
 

--- a/opsml/projects/project.py
+++ b/opsml/projects/project.py
@@ -2,19 +2,67 @@
 # Copyright (c) Shipt, Inc.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+# pylint: disable=protected-access
 
 from contextlib import contextmanager
 from typing import Any, Dict, Iterator, List, Optional, Union, cast
 
 from opsml.cards.base import ArtifactCard
+from opsml.cards.project import ProjectCard
 from opsml.cards.run import RunCard
 from opsml.helpers.logging import ArtifactLogger
 from opsml.projects._run_manager import ActiveRunException, _RunManager
 from opsml.projects.active_run import ActiveRun, CardHandler
 from opsml.projects.types import ProjectInfo
+from opsml.registry import CardRegistries
+from opsml.registry.sql.base.client import ClientProjectCardRegistry
 from opsml.types import CardInfo, CardType, Metric, Metrics, Param, Params
 
 logger = ArtifactLogger.get_logger()
+
+
+class _ProjectRegistrar:
+    def __init__(self, project_info: ProjectInfo):
+        self._project_info = project_info
+        self.registries = CardRegistries()
+
+    @property
+    def project_registry(self) -> ClientProjectCardRegistry:
+        # both server and client registries are the same for methods
+        return cast(ClientProjectCardRegistry, self.registries.project._registry)
+
+    def register_project(self) -> int:
+        """
+        Checks if the project name exists in the project registry. A ProjectCard is created if it
+        doesn't exist.
+
+        Returns:
+            project_id: int
+        """
+
+        # get project_id
+        project_id = self.project_registry.get_project_id(
+            project_name=self._project_info.name,
+            repository=self._project_info.repository,
+        )
+
+        if project_id is not None:
+            return project_id
+
+        # get nbr of unique projects
+        max_project = self.project_registry.get_max_project_id()
+
+        logger.info("New project detected! Registering card")
+
+        card = ProjectCard(
+            name=self._project_info.name,
+            repository=self._project_info.repository,
+            contact=self._project_info.contact,
+            project_id=max_project + 1,
+        )
+        self.registries.project.register_card(card=card)
+
+        return card.project_id
 
 
 class OpsmlProject:
@@ -56,7 +104,13 @@ class OpsmlProject:
                 as the project's current run.
         """
         # Set the run manager and project_id (creates ProjectCard if project doesn't exist)
-        self._run_mgr = _RunManager(project_info=info)
+        registrar = _ProjectRegistrar(project_info=info)
+
+        # get project id or register new project
+        info.project_id = registrar.register_project()
+
+        # crete run manager
+        self._run_mgr = _RunManager(project_info=info, registries=registrar.registries)
 
     @property
     def run_id(self) -> str:

--- a/opsml/projects/project.py
+++ b/opsml/projects/project.py
@@ -40,25 +40,10 @@ class _ProjectRegistrar:
             project_id: int
         """
 
-        # get project_id
-        project_id = self.project_registry.get_project_id(
-            project_name=self._project_info.name,
-            repository=self._project_info.repository,
-        )
-
-        if project_id is not None:
-            return project_id
-
-        # get nbr of unique projects
-        max_project = self.project_registry.get_max_project_id()
-
-        logger.info("New project detected! Registering card")
-
         card = ProjectCard(
             name=self._project_info.name,
             repository=self._project_info.repository,
             contact=self._project_info.contact,
-            project_id=max_project + 1,
         )
         self.registries.project.register_card(card=card)
 

--- a/opsml/projects/types.py
+++ b/opsml/projects/types.py
@@ -47,6 +47,12 @@ class ProjectInfo(BaseModel):
         description="Tracking URI. Defaults to OPSML_TRACKING_URI env variable",
     )
 
+    project_id: Optional[int] = Field(
+        default=None,
+        description="Optional project identifier. This is injected at runtime",
+        min_length=1,
+    )
+
     @field_validator("name", mode="before")
     def identifier_validator(cls, value: Optional[str]) -> Optional[str]:
         """Lowers and strips an identifier.

--- a/opsml/projects/types.py
+++ b/opsml/projects/types.py
@@ -23,18 +23,21 @@ class ProjectInfo(BaseModel):
         default=...,
         description="The project name",
         min_length=1,
+        frozen=True,
     )
 
     repository: str = Field(
         default="opsml",
         description="Optional repository to associate with the project. If not provided, defaults to opsml",
         min_length=1,
+        frozen=True,
     )
 
     contact: Optional[str] = Field(
         default=CommonKwargs.UNDEFINED.value,
         description="Optional contact information for the project",
         min_length=1,
+        frozen=True,
     )
 
     run_id: Optional[str] = Field(

--- a/opsml/registry/sql/base/client.py
+++ b/opsml/registry/sql/base/client.py
@@ -328,6 +328,46 @@ class ClientProjectCardRegistry(ClientRegistry):
     def validate(registry_name: str) -> bool:
         return registry_name.lower() == RegistryType.PROJECT.value
 
+    def get_project_id(self, project_name: str, repository: str) -> Optional[int]:
+        """get project id from project name and repository
+
+        Args:
+            project_name:
+                project name
+            repository:
+                repository name
+
+        Returns:
+            project id
+        """
+
+        data = self._session.get_request(
+            route=api_routes.PROJECT_ID,
+            params={
+                "project_name": project_name,
+                "repository": repository,
+            },
+        )
+
+        return data.get("project_id")
+
+    def get_max_project_id(self) -> int:
+        """get max project id
+
+        Returns:
+            max project id
+        """
+
+        data = self._session.get_request(
+            route=api_routes.MAX_PROJECT_ID,
+        )
+
+        project_id = data.get("project_id")
+
+        # max should never be none
+        assert project_id is not None
+        return cast(int, project_id)
+
     def delete_card(self, card: ArtifactCard) -> None:
         raise ValueError("ProjectCardRegistry does not support delete_card")
 

--- a/opsml/registry/sql/base/db_initializer.py
+++ b/opsml/registry/sql/base/db_initializer.py
@@ -1,6 +1,7 @@
 # Copyright (c) Shipt, Inc.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+import logging
 import os
 from pathlib import Path
 from typing import List
@@ -17,6 +18,9 @@ except ModuleNotFoundError as err:
 
 from opsml.helpers.logging import ArtifactLogger
 from opsml.registry.sql.base.sql_schema import Base
+
+# too much logging going on with alembic
+logging.getLogger("alembic").propagate = False
 
 logger = ArtifactLogger.get_logger()
 

--- a/opsml/registry/sql/base/query_engine.py
+++ b/opsml/registry/sql/base/query_engine.py
@@ -440,7 +440,25 @@ class QueryEngine:
 
 
 class ProjectQueryEngine(QueryEngine):
-    def get_project_id(self, project_name: str, repository: str) -> Optional[int]:
+    def get_max_project_id(self) -> int:
+        """Get max project id
+
+        Returns:
+            Max project id or 0
+        """
+        query = select(sqa_func.max(ProjectSchema.project_id))
+        with self.session() as sess:
+            result = sess.execute(query).first()
+            if not result:
+                return 0
+
+            max_project = result[0]
+
+            if max_project:
+                return cast(int, max_project)
+            return 0
+
+    def get_project_id(self, project_name: str, repository: str) -> int:
         """Get project id from project name and repository
 
         Args:
@@ -462,25 +480,8 @@ class ProjectQueryEngine(QueryEngine):
 
             if project_id:
                 return cast(int, project_id[0])
-            return None
 
-    def get_max_project_id(self) -> int:
-        """Get max project id
-
-        Returns:
-            Max project id or 0
-        """
-        query = select(sqa_func.max(ProjectSchema.project_id))
-        with self.session() as sess:
-            result = sess.execute(query).first()
-            if not result:
-                return 0
-
-            max_project = result[0]
-
-            if max_project:
-                return cast(int, max_project)
-            return 0
+        return self.get_max_project_id() + 1
 
 
 def get_query_engine(db_engine: Engine, registry_type: RegistryType) -> Union[QueryEngine, ProjectQueryEngine]:

--- a/opsml/registry/sql/base/server.py
+++ b/opsml/registry/sql/base/server.py
@@ -16,7 +16,7 @@ from opsml.registry.semver import (
     VersionType,
 )
 from opsml.registry.sql.base.db_initializer import DBInitializer
-from opsml.registry.sql.base.query_engine import QueryEngine
+from opsml.registry.sql.base.query_engine import ProjectQueryEngine, get_query_engine
 from opsml.registry.sql.base.registry_base import SQLRegistryBase
 from opsml.registry.sql.base.sql_schema import SQLTableGetter
 from opsml.registry.sql.base.utils import log_card_change
@@ -42,7 +42,7 @@ class ServerRegistry(SQLRegistryBase):
         )
         db_initializer.initialize()
 
-        self.engine = QueryEngine(db_initializer.engine)
+        self.engine = get_query_engine(db_engine=db_initializer.engine, registry_type=registry_type)
         self._table = SQLTableGetter.get_table(table_name=self.table_name)
 
     @property
@@ -346,6 +346,37 @@ class ServerProjectCardRegistry(ServerRegistry):
     @staticmethod
     def validate(registry_name: str) -> bool:
         return registry_name.lower() == RegistryType.PROJECT.value
+
+    def get_project_id(self, project_name: str, repository: str) -> Optional[int]:
+        """get project id from project name and repository
+
+        Args:
+            project_name:
+                project name
+            repository:
+                repository name
+
+        Returns:
+            project id
+
+        """
+        assert isinstance(self.engine, ProjectQueryEngine)
+
+        return self.engine.get_project_id(
+            project_name=project_name,
+            repository=repository,
+        )
+
+    def get_max_project_id(self) -> int:
+        """get max project id
+
+        Returns:
+            max project id
+
+        """
+        assert isinstance(self.engine, ProjectQueryEngine)
+
+        return self.engine.get_max_project_id()
 
     def delete_card(self, card: ArtifactCard) -> None:
         raise ValueError("ProjectCardRegistry does not support delete_card")

--- a/opsml/registry/sql/base/server.py
+++ b/opsml/registry/sql/base/server.py
@@ -6,6 +6,7 @@ import textwrap
 from typing import Any, Dict, List, Optional, Sequence, Tuple, cast
 
 from opsml.cards import ArtifactCard, ModelCard
+from opsml.cards.project import ProjectCard
 from opsml.helpers.logging import ArtifactLogger
 from opsml.helpers.utils import check_package_exists, clean_string
 from opsml.registry.semver import (
@@ -347,7 +348,30 @@ class ServerProjectCardRegistry(ServerRegistry):
     def validate(registry_name: str) -> bool:
         return registry_name.lower() == RegistryType.PROJECT.value
 
-    def get_project_id(self, project_name: str, repository: str) -> Optional[int]:
+    def delete_card(self, card: ArtifactCard) -> None:
+        raise ValueError("ProjectCardRegistry does not support delete_card")
+
+    def register_card(
+        self,
+        card: ArtifactCard,
+        version_type: VersionType = VersionType.MINOR,
+        pre_tag: str = "rc",
+        build_tag: str = "build",
+    ) -> None:
+        """Registers a ProjectCard to the registry"""
+        card = cast(ProjectCard, card)
+
+        # set project id on card even if its already registered
+        card.project_id = self.get_project_id(project_name=card.name, repository=card.repository)
+
+        # check if ProjectCard already exists
+        record = self.list_cards(name=card.name, repository=card.repository, limit=1)
+        if record:
+            return None
+
+        return super().register_card(card, version_type, pre_tag, build_tag)
+
+    def get_project_id(self, project_name: str, repository: str) -> int:
         """get project id from project name and repository
 
         Args:
@@ -366,20 +390,6 @@ class ServerProjectCardRegistry(ServerRegistry):
             project_name=project_name,
             repository=repository,
         )
-
-    def get_max_project_id(self) -> int:
-        """get max project id
-
-        Returns:
-            max project id
-
-        """
-        assert isinstance(self.engine, ProjectQueryEngine)
-
-        return self.engine.get_max_project_id()
-
-    def delete_card(self, card: ArtifactCard) -> None:
-        raise ValueError("ProjectCardRegistry does not support delete_card")
 
 
 class ServerAuditCardRegistry(ServerRegistry):

--- a/opsml/storage/api.py
+++ b/opsml/storage/api.py
@@ -31,7 +31,6 @@ class ApiRoutes:
     MODEL_METADATA = "models/metadata"
     MODEL_METRICS = "models/metrics"
     PROJECT_ID = "projects/id"
-    MAX_PROJECT_ID = "projects/max_id"
     DOWNLOAD_FILE = "files/download"
     DELETE_FILE = "files/delete"
     LIST_FILES = "files/list"

--- a/opsml/storage/api.py
+++ b/opsml/storage/api.py
@@ -2,11 +2,15 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import json as py_json
+import logging
 from pathlib import Path
 from typing import Any, Dict, Optional, cast
 
 import httpx
 from tenacity import retry, stop_after_attempt
+
+# httpx outputs a lot of logs
+logging.getLogger("httpx").propagate = False
 
 PATH_PREFIX = "opsml"
 
@@ -26,6 +30,8 @@ class ApiRoutes:
     REGISTER_MODEL = "models/register"
     MODEL_METADATA = "models/metadata"
     MODEL_METRICS = "models/metrics"
+    PROJECT_ID = "projects/id"
+    MAX_PROJECT_ID = "projects/max_id"
     DOWNLOAD_FILE = "files/download"
     DELETE_FILE = "files/delete"
     LIST_FILES = "files/list"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ Source = "https://github.com/shipt/opsml"
 
 [tool.poetry]
 name = "opsml"
-version = "2.1.6"
+version = "2.2.0"
 readme = "README.md"
 description = "Python MLOPs quality control tooling for your production ML workflows"
 authors = [

--- a/tests/test_projects/test_opsml_project_app.py
+++ b/tests/test_projects/test_opsml_project_app.py
@@ -1,0 +1,35 @@
+from starlette.testclient import TestClient
+
+from opsml.projects import OpsmlProject, ProjectInfo
+from opsml.registry.registry import CardRegistries
+
+# test_app already performs a few tests with opsml project in client model
+# Starting to add additional tests here to avoid further cluttering test_app
+
+
+def test_opsml_project_id_creation(test_app: TestClient, api_registries: CardRegistries) -> None:
+    """verify that we can read artifacts / metrics / cards without making a run
+    active."""
+    info = ProjectInfo(name="project1", repository="test", contact="user@test.com")
+    project = OpsmlProject(info=info)
+
+    with project.run() as run:
+        pass
+
+    assert project.project_id == 1
+
+    # create another project
+    info = ProjectInfo(name="project2", repository="test", contact="user@test.com")
+    project = OpsmlProject(info=info)
+    with project.run() as run:
+        pass
+
+    assert project.project_id == 2
+
+    # resume the first project
+    info = ProjectInfo(name="project1", repository="test", contact="user@test.com")
+    project = OpsmlProject(info=info)
+
+    with project.run() as run:
+        pass
+    assert project.project_id == 1


### PR DESCRIPTION
## Pull Request

### Short Summary
Updates project id logic to a more permanent solution

### Notes
- Moves project id logic out of `_RunManager` into a new class called `_ProjectRegistrar`
- Focus of new class is to (1) get project id or (2) create a new project given `name` and `repo`
- Getting project id and max project id have been moved to sql logic for performance
- Added new project/id and project/max_id routes 
- Added a new `ProjectQueryEngine` that has customized logic for the project registry
   - **NOTE** this is a slight departure since there is no longer a generic `QueryEngine` that all registries share
   - This is OK given that it will enable us to create registry specific logic on the backend if we ever need to without affecting public interfaces. There may be better ways to do this in the future though (don't know how good it is to call `_registry`. If we find that we are doing this a lot we should consider separating that logic out.



